### PR TITLE
feat: promote 4-6 to canonical model tier

### DIFF
--- a/src/adapter/cli-to-openai.ts
+++ b/src/adapter/cli-to-openai.ts
@@ -73,7 +73,7 @@ export function cliResultToOpenai(
   // Get model from modelUsage or default
   const modelName = result.modelUsage
     ? Object.keys(result.modelUsage)[0]
-    : "claude-sonnet-4";
+    : "claude-sonnet-4-6";
 
   const message: OpenAIChatResponse["choices"][0]["message"] = {
     role: "assistant",
@@ -107,12 +107,12 @@ export function cliResultToOpenai(
 
 /**
  * Normalize Claude model names to a consistent format
- * e.g., "claude-sonnet-4-5-20250929" -> "claude-sonnet-4"
+ * e.g., "claude-sonnet-4-5-20250929" -> "claude-sonnet-4-6"
  */
 function normalizeModelName(model: string | undefined): string {
-  if (!model) return "claude-sonnet-4";
-  if (model.includes("opus")) return "claude-opus-4";
-  if (model.includes("sonnet")) return "claude-sonnet-4";
-  if (model.includes("haiku")) return "claude-haiku-4";
+  if (!model) return "claude-sonnet-4-6";
+  if (model.includes("opus")) return "claude-opus-4-6";
+  if (model.includes("sonnet")) return "claude-sonnet-4-6";
+  if (model.includes("haiku")) return "claude-haiku-4-6";
   return model;
 }

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -15,11 +15,12 @@ export interface CliInput {
 const MODEL_MAP: Record<string, ClaudeModel> = {
   // Direct model names (provider prefixes like `claude-code-cli/` and `claude-max/`
   // are stripped by extractModel before consulting this map)
-  "claude-opus-4": "opus",
   "claude-opus-4-6": "opus",
+  "claude-opus-4": "opus",
+  "claude-sonnet-4-6": "sonnet",
   "claude-sonnet-4": "sonnet",
   "claude-sonnet-4-5": "sonnet",
-  "claude-sonnet-4-6": "sonnet",
+  "claude-haiku-4-6": "haiku",
   "claude-haiku-4": "haiku",
   "claude-haiku-4-5": "haiku",
   // Bare aliases

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -56,11 +56,12 @@ describe("health and models", () => {
 
     const ids = body.data.map((m: any) => m.id);
     for (const expected of [
-      "claude-opus-4",
       "claude-opus-4-6",
+      "claude-opus-4",
+      "claude-sonnet-4-6",
       "claude-sonnet-4",
       "claude-sonnet-4-5",
-      "claude-sonnet-4-6",
+      "claude-haiku-4-6",
       "claude-haiku-4",
       "claude-haiku-4-5",
     ]) {
@@ -100,7 +101,7 @@ describe("non-streaming completion", { timeout: TEST_TIMEOUT }, () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: "claude-haiku-4",
+        model: "claude-haiku-4-6",
         stream: false,
         messages: [
           {
@@ -169,7 +170,7 @@ describe("streaming completion", { timeout: TEST_TIMEOUT }, () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: "claude-haiku-4",
+        model: "claude-haiku-4-6",
         stream: true,
         messages: [
           {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,25 +12,25 @@ import { verifyClaude, verifyAuth } from "./subprocess/manager.js";
 const PROVIDER_ID = "claude-code-cli";
 const PROVIDER_LABEL = "Claude Code CLI";
 const DEFAULT_PORT = 3456;
-const DEFAULT_MODEL = "claude-code-cli/claude-sonnet-4";
+const DEFAULT_MODEL = "claude-code-cli/claude-sonnet-4-6";
 
 // Available models
 const AVAILABLE_MODELS = [
   {
-    id: "claude-opus-4",
-    name: "Claude Opus 4.5",
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
     alias: "opus",
     reasoning: true,
   },
   {
-    id: "claude-sonnet-4",
-    name: "Claude Sonnet 4",
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
     alias: "sonnet",
     reasoning: false,
   },
   {
-    id: "claude-haiku-4",
-    name: "Claude Haiku 4",
+    id: "claude-haiku-4-6",
+    name: "Claude Haiku 4.6",
     alias: "haiku",
     reasoning: false,
   },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -103,7 +103,7 @@ async function handleStreamingResponse(
 
   return new Promise<void>((resolve, reject) => {
     let isFirst = true;
-    let lastModel = "claude-sonnet-4";
+    let lastModel = "claude-sonnet-4-6";
     let isComplete = false;
     let hasEmittedText = false;
     let toolCallIndex = 0;
@@ -386,11 +386,12 @@ async function handleNonStreamingResponse(
 export function handleModels(_req: Request, res: Response): void {
   const now = Math.floor(Date.now() / 1000);
   const modelIds = [
-    "claude-opus-4",
     "claude-opus-4-6",
+    "claude-opus-4",
+    "claude-sonnet-4-6",
     "claude-sonnet-4",
     "claude-sonnet-4-5",
-    "claude-sonnet-4-6",
+    "claude-haiku-4-6",
     "claude-haiku-4",
     "claude-haiku-4-5",
   ];

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -49,7 +49,7 @@ async function main(): Promise<void> {
     console.log("\nServer ready. Test with:");
     console.log(`  curl -X POST http://localhost:${port}/v1/chat/completions \\`);
     console.log(`    -H "Content-Type: application/json" \\`);
-    console.log(`    -d '{"model": "claude-sonnet-4", "messages": [{"role": "user", "content": "Hello!"}]}'`);
+    console.log(`    -d '{"model": "claude-sonnet-4-6", "messages": [{"role": "user", "content": "Hello!"}]}'`);
     console.log("\nPress Ctrl+C to stop.\n");
   } catch (err) {
     console.error("Failed to start server:", err);


### PR DESCRIPTION
## Summary
- Switch primary model IDs from `claude-{opus,sonnet,haiku}-4` to `-4-6` across defaults, response normalization, the streaming `lastModel`, and example/test payloads
- Keep `-4` and `-4-5` IDs in `MODEL_MAP` and the `/v1/models` listing as backward-compatible aliases so existing clients don't break
- `normalizeModelName` now collapses any opus/sonnet/haiku variant to the corresponding `-4-6` ID

## Why
The proxy was advertising and defaulting to a `-4` tier that no longer matches the current Claude 4.6 generation served by the underlying CLI. New clients should see `-4-6` as the canonical name, while older clients calling `-4`/`-4-5` continue to route correctly.

## Test plan
- [x] `npm run build` (clean)
- [ ] Reviewer: confirm `/v1/models` still lists every legacy ID a downstream client may have hardcoded
- [ ] Reviewer: confirm no docs/configs outside `src/` still hardcode `claude-sonnet-4` as the default