### PR TITLE
fix: resolve native claude.exe on Windows instead of npm .cmd shim

### DIFF
--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -8,6 +8,7 @@
 import { spawn, ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import fs from "fs/promises";
+import { existsSync } from "fs";
 import path from "path";
 import type {
   ClaudeCliMessage,
@@ -43,6 +44,38 @@ export interface SubprocessEvents {
 }
 
 const DEFAULT_TIMEOUT = 900000; // 15 minutes
+
+/**
+ * Resolve the Claude CLI binary. On Windows, `claude` on PATH is an npm .cmd
+ * shim, which spawn() cannot execute without a shell (rejected since the
+ * Node 18 CVE-2024-27980 fix). The shim only forwards to a native claude.exe,
+ * so locate and use that exe directly instead.
+ */
+function resolveClaudeBin(): string {
+  if (process.env.CLAUDE_BIN) return process.env.CLAUDE_BIN;
+  if (process.platform === "win32") {
+    const candidates = [
+      process.env.APPDATA &&
+        path.join(
+          process.env.APPDATA,
+          "npm",
+          "node_modules",
+          "@anthropic-ai",
+          "claude-code",
+          "bin",
+          "claude.exe"
+        ),
+      process.env.USERPROFILE &&
+        path.join(process.env.USERPROFILE, ".local", "bin", "claude.exe"),
+    ];
+    for (const candidate of candidates) {
+      if (candidate && existsSync(candidate)) return candidate;
+    }
+  }
+  return "claude";
+}
+
+const CLAUDE_BIN = resolveClaudeBin();
 
 /**
  * System prompt appended to Claude CLI to map OpenClaw tool names to Claude Code equivalents.
@@ -104,7 +137,7 @@ export class ClaudeSubprocess extends EventEmitter {
     return new Promise((resolve, reject) => {
       try {
         // Use spawn() for security - no shell interpretation
-        this.process = spawn(process.env.CLAUDE_BIN || "claude", args, {
+        this.process = spawn(CLAUDE_BIN, args, {
           cwd: options.cwd || process.cwd(),
           env: Object.fromEntries(
             Object.entries(process.env).filter(([k]) => k !== "CLAUDECODE")
@@ -294,7 +327,7 @@ export class ClaudeSubprocess extends EventEmitter {
  */
 export async function verifyClaude(): Promise<{ ok: boolean; error?: string; version?: string }> {
   return new Promise((resolve) => {
-    const proc = spawn(process.env.CLAUDE_BIN || "claude", ["--version"], { stdio: "pipe" });
+    const proc = spawn(CLAUDE_BIN, ["--version"], { stdio: "pipe" });
     let output = "";
 
     proc.stdout?.on("data", (chunk: Buffer) => {

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -5,7 +5,7 @@
  * Uses spawn() instead of exec() to prevent shell injection vulnerabilities.
  */
 
-import { spawn, ChildProcess } from "child_process";
+import { spawn, spawnSync, ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import fs from "fs/promises";
 import { existsSync } from "fs";
@@ -49,33 +49,72 @@ const DEFAULT_TIMEOUT = 900000; // 15 minutes
  * Resolve the Claude CLI binary. On Windows, `claude` on PATH is an npm .cmd
  * shim, which spawn() cannot execute without a shell (rejected since the
  * Node 18 CVE-2024-27980 fix). The shim only forwards to a native claude.exe,
- * so locate and use that exe directly instead.
+ * so locate and use that exe directly.
+ *
+ * The CLAUDE_BIN env var is consulted on every call so it can be changed at
+ * runtime; the Windows exe lookup is deferred to first use (no filesystem I/O
+ * at import) and cached afterwards.
  */
-function resolveClaudeBin(): string {
+let cachedClaudeBin: string | undefined;
+
+function getClaudeBin(): string {
   if (process.env.CLAUDE_BIN) return process.env.CLAUDE_BIN;
-  if (process.platform === "win32") {
-    const candidates = [
-      process.env.APPDATA &&
-        path.join(
-          process.env.APPDATA,
-          "npm",
-          "node_modules",
-          "@anthropic-ai",
-          "claude-code",
-          "bin",
-          "claude.exe"
-        ),
-      process.env.USERPROFILE &&
-        path.join(process.env.USERPROFILE, ".local", "bin", "claude.exe"),
-    ];
-    for (const candidate of candidates) {
-      if (candidate && existsSync(candidate)) return candidate;
-    }
-  }
-  return "claude";
+  cachedClaudeBin ??= resolveWindowsClaudeExe() ?? "claude";
+  return cachedClaudeBin;
 }
 
-const CLAUDE_BIN = resolveClaudeBin();
+function resolveWindowsClaudeExe(): string | undefined {
+  if (process.platform !== "win32") return undefined;
+
+  const candidates: string[] = [];
+
+  // Locate claude on PATH via where.exe (spawned directly with fixed args, no
+  // shell). This handles custom npm prefixes and nvm-windows installs.
+  const where = spawnSync("where.exe", ["claude"], { encoding: "utf8" });
+  if (where.status === 0 && where.stdout) {
+    for (const entry of where.stdout.split(/\r?\n/)) {
+      const found = entry.trim();
+      if (!found) continue;
+      if (found.toLowerCase().endsWith(".exe")) {
+        candidates.push(found);
+      } else {
+        // npm shim (.cmd/.ps1/extensionless) forwards to the package's exe
+        candidates.push(
+          path.join(
+            path.dirname(found),
+            "node_modules",
+            "@anthropic-ai",
+            "claude-code",
+            "bin",
+            "claude.exe"
+          )
+        );
+      }
+    }
+  }
+
+  // Known install locations, in case claude is not on PATH at all
+  if (process.env.APPDATA) {
+    candidates.push(
+      path.join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "@anthropic-ai",
+        "claude-code",
+        "bin",
+        "claude.exe"
+      )
+    );
+  }
+  if (process.env.USERPROFILE) {
+    candidates.push(
+      path.join(process.env.USERPROFILE, ".local", "bin", "claude.exe")
+    );
+  }
+
+  return candidates.find((candidate) => existsSync(candidate));
+}
 
 /**
  * System prompt appended to Claude CLI to map OpenClaw tool names to Claude Code equivalents.
@@ -137,7 +176,7 @@ export class ClaudeSubprocess extends EventEmitter {
     return new Promise((resolve, reject) => {
       try {
         // Use spawn() for security - no shell interpretation
-        this.process = spawn(CLAUDE_BIN, args, {
+        this.process = spawn(getClaudeBin(), args, {
           cwd: options.cwd || process.cwd(),
           env: Object.fromEntries(
             Object.entries(process.env).filter(([k]) => k !== "CLAUDECODE")
@@ -327,7 +366,7 @@ export class ClaudeSubprocess extends EventEmitter {
  */
 export async function verifyClaude(): Promise<{ ok: boolean; error?: string; version?: string }> {
   return new Promise((resolve) => {
-    const proc = spawn(CLAUDE_BIN, ["--version"], { stdio: "pipe" });
+    const proc = spawn(getClaudeBin(), ["--version"], { stdio: "pipe" });
     let output = "";
 
     proc.stdout?.on("data", (chunk: Buffer) => {


### PR DESCRIPTION
## What

Fixes startup failure on Windows: the server always died with `Claude CLI not found` even with the CLI installed and authenticated.

## Why

The subprocess manager calls `spawn("claude", args)` with no shell. On Windows, `claude` on PATH is the npm-generated `claude.cmd` shim, and Node has refused to execute `.cmd`/`.bat` files without a shell since the CVE-2024-27980 fix (all supported Node versions, including the `>=20` this package requires). So both `verifyClaude()` at startup and every request spawn fail on every Windows install.

Using `shell: true` would fix it but reintroduce the shell-injection surface this project deliberately avoids (prompts are passed as CLI arguments).

## How

The `.cmd` shim is just a forwarder to a native `claude.exe`, so a new `resolveClaudeBin()` locates and spawns that exe directly:

1. `CLAUDE_BIN` env var, if set (unchanged, still wins everywhere)
2. On win32: `%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe` (npm global install)
3. On win32: `%USERPROFILE%\.local\bin\claude.exe` (native installer)
4. Fallback to `"claude"` (non-Windows behavior unchanged)

No shell involved, so the injection-safety design is preserved. Both spawn sites (`start()` and `verifyClaude()`) now use the resolved path.

## Testing

Verified end-to-end on Windows 11 (Node v24.16.0, Claude Code CLI 2.1.202, npm global install):

- Before: server exits at startup with `Claude CLI not found`
- After: startup passes CLI + auth checks; `GET /health` OK; `GET /v1/models` OK; non-streaming `POST /v1/chat/completions` returns completions; streaming returns SSE chunks and `[DONE]`
- `npm run build` clean

macOS/Linux behavior is unchanged (`CLAUDE_BIN` → `"claude"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)