### PR TITLE
feat: resume persisted CLI sessions instead of replaying full history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Thumbs.db
 
 # Test coverage
 coverage/
+
+# Local dev convenience scripts
+start-proxy.bat

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -20,6 +20,8 @@ const MODEL_MAP: Record<string, ClaudeModel> = {
   "claude-sonnet-4": "sonnet",
   "claude-sonnet-4-5": "sonnet",
   "claude-sonnet-4-6": "sonnet",
+  "claude-sonnet-5": "sonnet",
+  "claude-opus-5": "opus",
   "claude-haiku-4": "haiku",
   "claude-haiku-4-5": "haiku",
   // Bare aliases
@@ -140,5 +142,28 @@ export function openaiToCli(request: OpenAIChatRequest): CliInput {
     prompt: messagesToPrompt(request.messages),
     model: extractModel(request.model),
     sessionId: request.user, // Use OpenAI's user field for session mapping
+  };
+}
+
+/**
+ * Build CLI input for a request that will --resume an existing Claude CLI
+ * session. Since the CLI already remembers everything up to `sinceIndex`
+ * (it generated the assistant turns itself), we only need to forward the
+ * messages appended since then — not the full history again.
+ */
+export function openaiToCliDelta(
+  request: OpenAIChatRequest,
+  sinceIndex: number
+): CliInput {
+  const newMessages = request.messages
+    .slice(sinceIndex)
+    .filter((m) => m.role !== "assistant");
+
+  return {
+    // Fallback to full history if nothing new was found (shouldn't happen,
+    // but never send an empty prompt to the CLI)
+    prompt: messagesToPrompt(newMessages.length ? newMessages : request.messages),
+    model: extractModel(request.model),
+    sessionId: request.user,
   };
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7,13 +7,49 @@
 import type { Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
 import { ClaudeSubprocess } from "../subprocess/manager.js";
-import { openaiToCli } from "../adapter/openai-to-cli.js";
+import { openaiToCli, openaiToCliDelta } from "../adapter/openai-to-cli.js";
 import {
   cliResultToOpenai,
   createDoneChunk,
 } from "../adapter/cli-to-openai.js";
+import { getSession, setSession, clearSession } from "../subprocess/session-store.js";
 import type { OpenAIChatRequest, OpenAIToolCall } from "../types/openai.js";
 import type { ClaudeCliAssistant, ClaudeCliResult, ClaudeCliStreamEvent } from "../types/claude-cli.js";
+
+interface SessionContext {
+  sessionKey: string | undefined;
+  resume: boolean;
+  messageCount: number;
+}
+
+/**
+ * Resolve CLI input for a request, resuming a persisted Claude CLI session
+ * when we have one for this `request.user` key instead of replaying the
+ * full message history on every turn.
+ */
+function resolveCliInput(body: OpenAIChatRequest): {
+  cliInput: ReturnType<typeof openaiToCli>;
+  sessionKey: string | undefined;
+  resume: boolean;
+} {
+  // Default to a stable session key when the client (e.g. Hermes) doesn't
+  // send `user`. This enables --resume on subsequent turns, avoiding full
+  // history replay every request.
+  const sessionKey = body.user || "hermes-default-session";
+  const existing = getSession(sessionKey);
+
+  if (existing) {
+    const cliInput = openaiToCliDelta(body, existing.messageCount);
+    cliInput.sessionId = existing.claudeSessionId;
+    return { cliInput, sessionKey, resume: true };
+  }
+
+  const cliInput = openaiToCli(body);
+  if (sessionKey) {
+    cliInput.sessionId = uuidv4(); // pin a known ID so we can --resume it later
+  }
+  return { cliInput, sessionKey, resume: false };
+}
 
 /**
  * Handle POST /v1/chat/completions
@@ -41,14 +77,15 @@ export async function handleChatCompletions(
       return;
     }
 
-    // Convert to CLI input format
-    const cliInput = openaiToCli(body);
+    // Convert to CLI input format, resuming a persisted session when we have one
+    const { cliInput, sessionKey, resume } = resolveCliInput(body);
     const subprocess = new ClaudeSubprocess();
+    const sessionCtx: SessionContext = { sessionKey, resume, messageCount: body.messages.length };
 
     if (stream) {
-      await handleStreamingResponse(req, res, subprocess, cliInput, requestId);
+      await handleStreamingResponse(req, res, subprocess, cliInput, requestId, sessionCtx);
     } else {
-      await handleNonStreamingResponse(res, subprocess, cliInput, requestId);
+      await handleNonStreamingResponse(res, subprocess, cliInput, requestId, sessionCtx);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -86,7 +123,8 @@ async function handleStreamingResponse(
   res: Response,
   subprocess: ClaudeSubprocess,
   cliInput: ReturnType<typeof openaiToCli>,
-  requestId: string
+  requestId: string,
+  sessionCtx: SessionContext
 ): Promise<void> {
   // Set SSE headers
   res.setHeader("Content-Type", "text/event-stream");
@@ -242,6 +280,9 @@ async function handleStreamingResponse(
 
     subprocess.on("result", (result: ClaudeCliResult) => {
       isComplete = true;
+      if (sessionCtx.sessionKey && cliInput.sessionId) {
+        setSession(sessionCtx.sessionKey, cliInput.sessionId, sessionCtx.messageCount);
+      }
       if (!res.writableEnded) {
         // Send final done chunk with finish_reason and usage data
         const doneChunk = createDoneChunk(requestId, lastModel);
@@ -262,6 +303,11 @@ async function handleStreamingResponse(
 
     subprocess.on("error", (error: Error) => {
       console.error("[Streaming] Error:", error.message);
+      // Resume may have failed (e.g. stale/missing session) — drop it so the
+      // next turn self-heals with a fresh full-history session
+      if (sessionCtx.resume && sessionCtx.sessionKey) {
+        clearSession(sessionCtx.sessionKey);
+      }
       if (!res.writableEnded) {
         res.write(
           `data: ${JSON.stringify({
@@ -275,13 +321,18 @@ async function handleStreamingResponse(
 
     subprocess.on("close", (code: number | null) => {
       // Subprocess exited - ensure response is closed
-      if (!res.writableEnded) {
-        if (code !== 0 && !isComplete) {
+      if (code !== 0 && !isComplete) {
+        if (sessionCtx.resume && sessionCtx.sessionKey) {
+          clearSession(sessionCtx.sessionKey);
+        }
+        if (!res.writableEnded) {
           // Abnormal exit without result - send error
           res.write(`data: ${JSON.stringify({
             error: { message: `Process exited with code ${code}`, type: "server_error", code: null },
           })}\n\n`);
         }
+      }
+      if (!res.writableEnded) {
         res.write("data: [DONE]\n\n");
         res.end();
       }
@@ -292,6 +343,7 @@ async function handleStreamingResponse(
     subprocess.start(cliInput.prompt, {
       model: cliInput.model,
       sessionId: cliInput.sessionId,
+      resume: sessionCtx.resume,
     }).catch((err) => {
       console.error("[Streaming] Subprocess start error:", err);
       reject(err);
@@ -306,7 +358,8 @@ async function handleNonStreamingResponse(
   res: Response,
   subprocess: ClaudeSubprocess,
   cliInput: ReturnType<typeof openaiToCli>,
-  requestId: string
+  requestId: string,
+  sessionCtx: SessionContext
 ): Promise<void> {
   return new Promise((resolve) => {
     let finalResult: ClaudeCliResult | null = null;
@@ -334,6 +387,9 @@ async function handleNonStreamingResponse(
 
     subprocess.on("error", (error: Error) => {
       console.error("[NonStreaming] Error:", error.message);
+      if (sessionCtx.resume && sessionCtx.sessionKey) {
+        clearSession(sessionCtx.sessionKey);
+      }
       res.status(500).json({
         error: {
           message: error.message,
@@ -346,15 +402,23 @@ async function handleNonStreamingResponse(
 
     subprocess.on("close", (code: number | null) => {
       if (finalResult) {
+        if (sessionCtx.sessionKey && cliInput.sessionId) {
+          setSession(sessionCtx.sessionKey, cliInput.sessionId, sessionCtx.messageCount);
+        }
         res.json(cliResultToOpenai(finalResult, requestId));
-      } else if (!res.headersSent) {
-        res.status(500).json({
-          error: {
-            message: `Claude CLI exited with code ${code} without response`,
-            type: "server_error",
-            code: null,
-          },
-        });
+      } else {
+        if (sessionCtx.resume && sessionCtx.sessionKey) {
+          clearSession(sessionCtx.sessionKey);
+        }
+        if (!res.headersSent) {
+          res.status(500).json({
+            error: {
+              message: `Claude CLI exited with code ${code} without response`,
+              type: "server_error",
+              code: null,
+            },
+          });
+        }
       }
       resolve();
     });
@@ -364,6 +428,7 @@ async function handleNonStreamingResponse(
       .start(cliInput.prompt, {
         model: cliInput.model,
         sessionId: cliInput.sessionId,
+        resume: sessionCtx.resume,
       })
       .catch((error) => {
         res.status(500).json({
@@ -391,6 +456,8 @@ export function handleModels(_req: Request, res: Response): void {
     "claude-sonnet-4",
     "claude-sonnet-4-5",
     "claude-sonnet-4-6",
+    "claude-sonnet-5",
+    "claude-opus-5",
     "claude-haiku-4",
     "claude-haiku-4-5",
   ];

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -32,11 +32,12 @@ function resolveCliInput(body: OpenAIChatRequest): {
   sessionKey: string | undefined;
   resume: boolean;
 } {
-  // Default to a stable session key when the client (e.g. Hermes) doesn't
-  // send `user`. This enables --resume on subsequent turns, avoiding full
-  // history replay every request.
-  const sessionKey = body.user || "hermes-default-session";
-  const existing = getSession(sessionKey);
+  // Session resume requires a stable per-client identifier. Without `user`
+  // we have no way to distinguish callers, so skip resume entirely rather
+  // than fall back to a shared key that would cross-contaminate unrelated
+  // conversations.
+  const sessionKey = body.user;
+  const existing = sessionKey ? getSession(sessionKey) : undefined;
 
   if (existing) {
     const cliInput = openaiToCliDelta(body, existing.messageCount);

--- a/src/subprocess/manager.test.ts
+++ b/src/subprocess/manager.test.ts
@@ -1,0 +1,339 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, afterEach, before, describe, it } from "node:test";
+import { ClaudeSubprocess } from "./manager.js";
+
+const WINDOWS_ONLY = process.platform !== "win32";
+const WAIT_TIMEOUT_MS = 5_000;
+const GENEROUS_REQUEST_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 100;
+
+describe("Windows process-tree termination", { skip: WINDOWS_ONLY }, () => {
+  let fixtureDir: string;
+  let fixturePath: string;
+  let previousClaudeBin: string | undefined;
+  const cleanupPids = new Set<number>();
+
+  before(async () => {
+    previousClaudeBin = process.env.CLAUDE_BIN;
+    fixtureDir = await mkdtemp(path.join(tmpdir(), "claude-process-tree-"));
+    const descendantPath = path.join(fixtureDir, "descendant.cjs");
+    fixturePath = path.join(fixtureDir, "process-tree.cjs");
+    await writeFile(
+      descendantPath,
+      [
+        'const { writeFileSync } = require("node:fs");',
+        "writeFileSync(process.argv[2], \"ready\");",
+        "setInterval(() => {}, 1000);",
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(
+      fixturePath,
+      [
+        'const { spawn } = require("node:child_process");',
+        'const { existsSync, unlinkSync } = require("node:fs");',
+        'const { join } = require("node:path");',
+        'const readyPath = join(__dirname, `descendant-${process.pid}.ready`);',
+        'try { unlinkSync(readyPath); } catch {}',
+        `const descendant = spawn(process.execPath, [${JSON.stringify(descendantPath)}, readyPath], { detached: true, stdio: "ignore" });`,
+        "descendant.unref();",
+        "const readinessCheck = setInterval(() => {",
+        "  if (!existsSync(readyPath)) return;",
+        "  clearInterval(readinessCheck);",
+        '  process.stdout.write(JSON.stringify({ descendantPid: descendant.pid }) + "\\n");',
+        "}, 10);",
+        "setInterval(() => {}, 1000);",
+      ].join("\n"),
+      "utf8"
+    );
+
+    // Use a controlled binary for every ClaudeSubprocess in this suite.
+    process.env.CLAUDE_BIN = process.execPath;
+  });
+
+  afterEach(async () => {
+    await cleanupTrackedProcesses(cleanupPids);
+  });
+
+  after(async () => {
+    let cleanupError: unknown;
+    try {
+      await cleanupTrackedProcesses(cleanupPids);
+      if (cleanupPids.size > 0) {
+        cleanupError = new Error(
+          `failed to terminate fixture processes: ${[...cleanupPids].join(", ")}`
+        );
+      }
+    } catch (error) {
+      cleanupError = error;
+    } finally {
+      restoreEnvironmentVariable("CLAUDE_BIN", previousClaudeBin);
+      try {
+        await rm(fixtureDir, { recursive: true, force: true });
+      } catch (error) {
+        cleanupError = cleanupError
+          ? new AggregateError([cleanupError, error], "fixture cleanup failed")
+          : error;
+      }
+    }
+    if (cleanupError) throw cleanupError;
+  });
+
+  it("demonstrates that killing only the direct child leaves its descendant alive", async () => {
+    const parent = spawn(process.execPath, [fixturePath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    trackChild(parent, cleanupPids);
+    const descendantPid = await readDescendantPid(parent);
+    cleanupPids.add(descendantPid);
+
+    assert.equal(parent.kill(), true, "the direct parent should accept termination");
+    await waitForExit(parent);
+
+    assert.equal(
+      isProcessAlive(descendantPid),
+      true,
+      "direct-child termination should reproduce the leaked descendant"
+    );
+  });
+
+  it("kills the full process tree when kill() is called", async () => {
+    const subprocess = createFixtureSubprocess();
+    const descendantPidPromise = readManagerDescendantPid(subprocess);
+    subprocess.on("error", () => {});
+
+    await subprocess.start("", { model: "haiku", timeout: WAIT_TIMEOUT_MS });
+    const rootPid = trackManagerProcess(subprocess, cleanupPids);
+    const descendantPid = await descendantPidPromise;
+    cleanupPids.add(descendantPid);
+
+    subprocess.kill();
+
+    await waitForProcessToStop(rootPid);
+    await waitForProcessToStop(descendantPid);
+    assert.equal(isProcessAlive(rootPid), false);
+    assert.equal(isProcessAlive(descendantPid), false);
+  });
+
+  it("kills the full process tree when the request times out", async () => {
+    const subprocess = createFixtureSubprocess();
+    const descendantPidPromise = readManagerDescendantPid(subprocess);
+    const timeoutErrorPromise = new Promise<Error>((resolve) => {
+      subprocess.once("error", resolve);
+    });
+
+    await subprocess.start("", {
+      model: "haiku",
+      timeout: GENEROUS_REQUEST_TIMEOUT_MS,
+    });
+    const rootPid = trackManagerProcess(subprocess, cleanupPids);
+    const descendantPid = await descendantPidPromise;
+    cleanupPids.add(descendantPid);
+    const testable = subprocess as unknown as {
+      armTimeout: (timeout: number) => void;
+    };
+    testable.armTimeout(REQUEST_TIMEOUT_MS);
+    const timeoutError = await timeoutErrorPromise;
+
+    assert.match(timeoutError.message, new RegExp(`Request timed out after ${REQUEST_TIMEOUT_MS}ms`));
+    await waitForProcessToStop(rootPid);
+    await waitForProcessToStop(descendantPid);
+    assert.equal(isProcessAlive(rootPid), false);
+    assert.equal(isProcessAlive(descendantPid), false);
+  });
+
+  it("keeps isKilled false when taskkill cannot launch", async () => {
+    const subprocess = createFixtureSubprocess();
+    const descendantPidPromise = readManagerDescendantPid(subprocess);
+    subprocess.on("error", () => {});
+
+    await subprocess.start("", {
+      model: "haiku",
+      timeout: GENEROUS_REQUEST_TIMEOUT_MS,
+    });
+    const rootPid = trackManagerProcess(subprocess, cleanupPids);
+    const descendantPid = await descendantPidPromise;
+    cleanupPids.add(descendantPid);
+
+    const testable = subprocess as unknown as {
+      process: ChildProcess | null;
+      isKilled: boolean;
+    };
+    assert.ok(testable.process, "manager did not retain its root process");
+    const managedProcess = testable.process;
+    const originalKill = managedProcess.kill.bind(managedProcess);
+    let directKillSucceeded = false;
+    managedProcess.kill = ((signal?: NodeJS.Signals | number) => {
+      directKillSucceeded = originalKill(signal);
+      return directKillSucceeded;
+    }) as ChildProcess["kill"];
+
+    const previousSystemRoot = process.env.SystemRoot;
+    try {
+      process.env.SystemRoot = path.join(fixtureDir, "missing-system-root");
+      subprocess.kill();
+    } finally {
+      restoreEnvironmentVariable("SystemRoot", previousSystemRoot);
+    }
+
+    assert.equal(directKillSucceeded, true, "direct child kill should succeed");
+    assert.equal(testable.isKilled, false, "failed taskkill must not set isKilled");
+    await waitForProcessToStop(rootPid);
+    assert.equal(isProcessAlive(rootPid), false);
+    assert.equal(
+      isProcessAlive(descendantPid),
+      true,
+      "failed tree termination should leave the detached descendant for retry"
+    );
+  });
+
+  function createFixtureSubprocess(): ClaudeSubprocess {
+    const subprocess = new ClaudeSubprocess();
+    const testable = subprocess as unknown as { buildArgs: () => string[] };
+    testable.buildArgs = () => [fixturePath];
+    return subprocess;
+  }
+});
+
+function trackChild(child: ChildProcess, cleanupPids: Set<number>): number {
+  const pid = child.pid;
+  assert.equal(typeof pid, "number", "fixture root did not receive a PID");
+  cleanupPids.add(pid as number);
+  return pid as number;
+}
+
+function trackManagerProcess(
+  subprocess: ClaudeSubprocess,
+  cleanupPids: Set<number>
+): number {
+  const managed = subprocess as unknown as { process: ChildProcess | null };
+  assert.ok(managed.process, "manager did not retain its root process");
+  return trackChild(managed.process, cleanupPids);
+}
+
+function readManagerDescendantPid(subprocess: ClaudeSubprocess): Promise<number> {
+  return withTimeout(
+    new Promise<number>((resolve, reject) => {
+      subprocess.on("message", (message: { descendantPid?: number }) => {
+        if (typeof message.descendantPid !== "number") {
+          reject(new Error("manager fixture reported an invalid descendant PID"));
+          return;
+        }
+        resolve(message.descendantPid);
+      });
+    }),
+    "manager fixture did not report its descendant PID"
+  );
+}
+
+function readDescendantPid(parent: ChildProcess): Promise<number> {
+  return withTimeout(
+    new Promise<number>((resolve, reject) => {
+      let stdout = "";
+      parent.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+        const newline = stdout.indexOf("\n");
+        if (newline !== -1) {
+          try {
+            const message = JSON.parse(stdout.slice(0, newline)) as {
+              descendantPid?: number;
+            };
+            if (typeof message.descendantPid !== "number") {
+              reject(new Error("fixture reported an invalid descendant PID"));
+              return;
+            }
+            resolve(message.descendantPid);
+          } catch (error) {
+            reject(error);
+          }
+        }
+      });
+      parent.once("error", reject);
+    }),
+    "direct-child fixture did not report its descendant PID"
+  );
+}
+
+function waitForExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null) return Promise.resolve();
+  return withTimeout(
+    new Promise<void>((resolve) => child.once("close", () => resolve())),
+    "direct child did not exit"
+  );
+}
+
+async function waitForProcessToStop(pid: number): Promise<void> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.fail(`process ${pid} was still alive after ${WAIT_TIMEOUT_MS}ms`);
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function terminateTree(pid: number): Promise<boolean> {
+  if (!isProcessAlive(pid)) return true;
+  const taskkill = process.env.SystemRoot
+    ? path.join(process.env.SystemRoot, "System32", "taskkill.exe")
+    : "taskkill.exe";
+  const result = spawnSync(taskkill, ["/PID", String(pid), "/T", "/F"], {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  if (result.error || result.status !== 0) return false;
+  return waitForProcessToStopWithoutAssertion(pid);
+}
+
+async function cleanupTrackedProcesses(cleanupPids: Set<number>): Promise<void> {
+  for (const pid of [...cleanupPids]) {
+    if (await terminateTree(pid)) {
+      cleanupPids.delete(pid);
+    }
+  }
+}
+
+async function waitForProcessToStopWithoutAssertion(pid: number): Promise<boolean> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return !isProcessAlive(pid);
+}
+
+function restoreEnvironmentVariable(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), WAIT_TIMEOUT_MS);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -5,9 +5,10 @@
  * Uses spawn() instead of exec() to prevent shell injection vulnerabilities.
  */
 
-import { spawn, ChildProcess } from "child_process";
+import { spawn, spawnSync, ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import fs from "fs/promises";
+import { readFileSync } from "fs";
 import path from "path";
 import type {
   ClaudeCliMessage,
@@ -29,6 +30,8 @@ import type { ClaudeModel } from "../adapter/openai-to-cli.js";
 export interface SubprocessOptions {
   model: ClaudeModel;
   sessionId?: string;
+  /** Resume an existing persisted session (sessionId) instead of creating a new one */
+  resume?: boolean;
   cwd?: string;
   timeout?: number;
 }
@@ -88,6 +91,59 @@ const OPENCLAW_TOOL_MAPPING_PROMPT = [
   "Run `openclaw skills list --eligible --json` to see all available skills.",
 ].join("\n");
 
+/**
+ * Resolve the real Claude CLI binary to spawn.
+ *
+ * On Windows, the global `claude` command is an npm shim (`claude.cmd`) that
+ * just execs a bundled `claude.exe`. Running the shim requires `shell: true`,
+ * which routes our argv through cmd.exe — and cmd.exe treats characters our
+ * appended system prompt legitimately contains (`<`, `>`, `(`, `)`, `&`) as
+ * redirection/grouping/chaining operators, corrupting the argument list that
+ * follows (notably `--session-id`/`--resume`, which silently stop working).
+ * Resolving straight to the `.exe` lets us spawn with `shell: false` and
+ * skip cmd.exe entirely. Falls back to the shim (with shell:true) if the
+ * `.exe` can't be located.
+ */
+let resolvedClaudeBin: { bin: string; shell: boolean } | null = null;
+
+function resolveClaudeBin(): { bin: string; shell: boolean } {
+  if (resolvedClaudeBin) return resolvedClaudeBin;
+
+  if (process.env.CLAUDE_BIN) {
+    resolvedClaudeBin = { bin: process.env.CLAUDE_BIN, shell: false };
+    return resolvedClaudeBin;
+  }
+
+  if (process.platform === "win32") {
+    try {
+      const where = spawnSync("where.exe", ["claude"], { encoding: "utf8" });
+      const shimPath = (where.stdout || "")
+        .split(/\r?\n/)
+        .map((p) => p.trim())
+        .find((p) => p.toLowerCase().endsWith(".cmd"));
+
+      if (shimPath) {
+        const shimDir = path.dirname(shimPath);
+        const shimContent = readFileSync(shimPath, "utf8");
+        const match = shimContent.match(/"%dp0%\\(.+?\.exe)"/i);
+        if (match) {
+          const exePath = path.join(shimDir, match[1]);
+          resolvedClaudeBin = { bin: exePath, shell: false };
+          return resolvedClaudeBin;
+        }
+      }
+    } catch {
+      // Fall through to shim fallback below
+    }
+
+    resolvedClaudeBin = { bin: "claude", shell: true };
+    return resolvedClaudeBin;
+  }
+
+  resolvedClaudeBin = { bin: "claude", shell: false };
+  return resolvedClaudeBin;
+}
+
 export class ClaudeSubprocess extends EventEmitter {
   private process: ChildProcess | null = null;
   private buffer: string = "";
@@ -100,16 +156,22 @@ export class ClaudeSubprocess extends EventEmitter {
   async start(prompt: string, options: SubprocessOptions): Promise<void> {
     const args = this.buildArgs(options);
     const timeout = options.timeout || DEFAULT_TIMEOUT;
+    if (process.env.DEBUG_SUBPROCESS) {
+      console.error(`[Subprocess] args: ${JSON.stringify(args)}`);
+      console.error(`[Subprocess] prompt: ${prompt.slice(0, 200)}`);
+    }
 
     return new Promise((resolve, reject) => {
       try {
         // Use spawn() for security - no shell interpretation
-        this.process = spawn(process.env.CLAUDE_BIN || "claude", args, {
+        const { bin, shell } = resolveClaudeBin();
+        this.process = spawn(bin, args, {
           cwd: options.cwd || process.cwd(),
           env: Object.fromEntries(
             Object.entries(process.env).filter(([k]) => k !== "CLAUDECODE")
           ),
           stdio: ["pipe", "pipe", "pipe"],
+          shell,
         });
 
         // Set timeout
@@ -200,14 +262,22 @@ export class ClaudeSubprocess extends EventEmitter {
       "--include-partial-messages", // Enable streaming chunks
       "--model",
       options.model, // Model alias (opus/sonnet/haiku)
-      "--no-session-persistence", // Don't save sessions
       "--append-system-prompt",
       OPENCLAW_TOOL_MAPPING_PROMPT,
       // Prompt is passed via stdin (avoids E2BIG on large inputs)
     ];
 
-    if (options.sessionId) {
+    if (options.sessionId && options.resume) {
+      // Continue a previously persisted session — avoids replaying full history
+      args.push("--resume", options.sessionId);
+    } else if (options.sessionId) {
+      // First turn for this session key — create it under a known ID so we
+      // can --resume it on subsequent turns
       args.push("--session-id", options.sessionId);
+    } else {
+      // No stable session key (e.g. request.user missing) — don't leave
+      // orphaned session files behind
+      args.push("--no-session-persistence");
     }
 
     return args;
@@ -294,7 +364,8 @@ export class ClaudeSubprocess extends EventEmitter {
  */
 export async function verifyClaude(): Promise<{ ok: boolean; error?: string; version?: string }> {
   return new Promise((resolve) => {
-    const proc = spawn(process.env.CLAUDE_BIN || "claude", ["--version"], { stdio: "pipe" });
+    const { bin, shell } = resolveClaudeBin();
+    const proc = spawn(bin, ["--version"], { stdio: "pipe", shell });
     let output = "";
 
     proc.stdout?.on("data", (chunk: Buffer) => {

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -107,12 +107,13 @@ const OPENCLAW_TOOL_MAPPING_PROMPT = [
 let resolvedClaudeBin: { bin: string; shell: boolean } | null = null;
 
 function resolveClaudeBin(): { bin: string; shell: boolean } {
-  if (resolvedClaudeBin) return resolvedClaudeBin;
-
   if (process.env.CLAUDE_BIN) {
-    resolvedClaudeBin = { bin: process.env.CLAUDE_BIN, shell: false };
-    return resolvedClaudeBin;
+    // Environment overrides are intentionally not cached. This lets callers
+    // temporarily select a binary without contaminating later resolutions.
+    return { bin: process.env.CLAUDE_BIN, shell: false };
   }
+
+  if (resolvedClaudeBin) return resolvedClaudeBin;
 
   if (process.platform === "win32") {
     try {
@@ -142,6 +143,52 @@ function resolveClaudeBin(): { bin: string; shell: boolean } {
 
   resolvedClaudeBin = { bin: "claude", shell: false };
   return resolvedClaudeBin;
+}
+
+/**
+ * Kill a process and its full descendant tree.
+ *
+ * `ChildProcess.kill()` only signals the direct child. On Windows this is
+ * insufficient because the Claude CLI spawns its own subprocesses (e.g. for
+ * Bash tool calls) that aren't part of a job object — killing just the
+ * parent leaves them running in the background even after a client
+ * disconnect or timeout. `taskkill /T` walks the whole tree instead.
+ */
+function killProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM"
+): boolean {
+  const pid = child.pid;
+  if (!pid) return false;
+
+  if (process.platform === "win32") {
+    const taskkill = process.env.SystemRoot
+      ? path.join(process.env.SystemRoot, "System32", "taskkill.exe")
+      : "taskkill.exe";
+    const result = spawnSync(taskkill, ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    if (!result.error && result.status === 0) {
+      return true;
+    }
+
+    // If taskkill could not be started or rejected the request, still make a
+    // best-effort attempt to stop the managed root process. This must not be
+    // reported as a successful tree termination: descendants may still be
+    // running, and callers must remain able to retry.
+    try {
+      child.kill(signal);
+    } catch {}
+    return false;
+  }
+
+  try {
+    return child.kill(signal);
+  } catch {
+    // Process may have already exited
+    return false;
+  }
 }
 
 export class ClaudeSubprocess extends EventEmitter {
@@ -174,14 +221,7 @@ export class ClaudeSubprocess extends EventEmitter {
           shell,
         });
 
-        // Set timeout
-        this.timeoutId = setTimeout(() => {
-          if (!this.isKilled) {
-            this.isKilled = true;
-            this.process?.kill("SIGTERM");
-            this.emit("error", new Error(`Request timed out after ${timeout}ms`));
-          }
-        }, timeout);
+        this.armTimeout(timeout);
 
         // Handle spawn errors (e.g., claude not found)
         this.process.on("error", (err) => {
@@ -345,10 +385,25 @@ export class ClaudeSubprocess extends EventEmitter {
    */
   kill(signal: NodeJS.Signals = "SIGTERM"): void {
     if (!this.isKilled && this.process) {
-      this.isKilled = true;
       this.clearTimeout();
-      this.process.kill(signal);
+      this.isKilled = killProcessTree(this.process, signal);
     }
+  }
+
+  /**
+   * Arm the request timeout. Kept narrow so tests can deterministically re-arm
+   * the production timeout behavior after their fixture process tree is ready.
+   */
+  private armTimeout(timeout: number): void {
+    this.clearTimeout();
+    this.timeoutId = setTimeout(() => {
+      if (!this.isKilled) {
+        if (this.process) {
+          this.isKilled = killProcessTree(this.process, "SIGTERM");
+        }
+        this.emit("error", new Error(`Request timed out after ${timeout}ms`));
+      }
+    }, timeout);
   }
 
   /**

--- a/src/subprocess/session-store.ts
+++ b/src/subprocess/session-store.ts
@@ -1,0 +1,38 @@
+/**
+ * In-memory mapping from OpenAI request.user (Hermes conversation key) to a
+ * persisted Claude CLI session. Lets the proxy --resume an existing CLI
+ * session instead of cold-starting a fresh one and replaying the entire
+ * message history on every request.
+ */
+
+interface SessionEntry {
+  claudeSessionId: string;
+  messageCount: number;
+  lastUsed: number;
+}
+
+const SESSION_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours of inactivity
+
+const sessions = new Map<string, SessionEntry>();
+
+export function getSession(key: string): SessionEntry | undefined {
+  const entry = sessions.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.lastUsed > SESSION_TTL_MS) {
+    sessions.delete(key);
+    return undefined;
+  }
+  return entry;
+}
+
+export function setSession(
+  key: string,
+  claudeSessionId: string,
+  messageCount: number
+): void {
+  sessions.set(key, { claudeSessionId, messageCount, lastUsed: Date.now() });
+}
+
+export function clearSession(key: string): void {
+  sessions.delete(key);
+}

--- a/src/subprocess/session-store.ts
+++ b/src/subprocess/session-store.ts
@@ -12,8 +12,24 @@ interface SessionEntry {
 }
 
 const SESSION_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours of inactivity
+const PRUNE_INTERVAL_MS = 30 * 60 * 1000; // sweep every 30 minutes
 
 const sessions = new Map<string, SessionEntry>();
+
+function pruneExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of sessions) {
+    if (now - entry.lastUsed > SESSION_TTL_MS) {
+      sessions.delete(key);
+    }
+  }
+}
+
+// Sessions that are set once and never queried again (e.g. a client that
+// stops sending `user`) would otherwise sit in memory forever, since TTL
+// was previously only enforced on read. Sweep periodically so idle server
+// processes don't accumulate unbounded entries.
+setInterval(pruneExpired, PRUNE_INTERVAL_MS).unref();
 
 export function getSession(key: string): SessionEntry | undefined {
   const entry = sessions.get(key);

--- a/start-proxy.bat
+++ b/start-proxy.bat
@@ -1,3 +1,0 @@
-@echo off
-cd /d C:\Users\canch\AppData\Local\claude-max-api-proxy
-node dist/server/standalone.js 3456

--- a/start-proxy.bat
+++ b/start-proxy.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d C:\Users\canch\AppData\Local\claude-max-api-proxy
+node dist/server/standalone.js 3456


### PR DESCRIPTION
## Summary
- Adds a session store mapping `request.user` -> Claude CLI session ID, so repeat turns `--resume` the existing CLI session and send only the delta messages instead of replaying the full conversation history every request.
- Fixes Windows arg corruption: the global `claude` command is an npm shim (`claude.cmd`) that requires `shell: true`, which routes args through cmd.exe and mangles characters like `<`, `>`, `&` in the appended system prompt (breaking `--session-id`/`--resume`). Now resolves directly to the bundled `claude.exe` and spawns with `shell: false`.
- Adds `claude-sonnet-5` / `claude-opus-5` model aliases.

## Test plan
- [x] `npm run build` compiles cleanly
- [x] Restarted local proxy, verified `/v1/models` responds
- [x] Verified session resume in practice via Hermes chat (repeat turns noticeably faster, no full-history replay)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)