### PR TITLE
feat: Dockerfile for containerized deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.gitignore
+.env
+*.md
+!README.md
+docs
+.DS_Store
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# ---- Build stage ----
+FROM node:22-slim AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ---- Runtime stage ----
+FROM node:22-slim
+
+# Claude Code CLI - the proxy wraps it as a subprocess.
+# The CLI reads its OAuth credentials from $CLAUDE_CONFIG_DIR (default ~/.claude),
+# so mount a persistent volume there.
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+
+# Non-root user for the proxy process. Note: node:*-slim images already
+# ship a system user named "proxy", so we use a distinct name.
+RUN useradd --create-home --shell /bin/bash proxyapp \
+  && mkdir -p /data/.claude \
+  && chown -R proxyapp:proxyapp /data /app
+USER proxyapp
+
+# Claude CLI config/credentials live here - mount a volume on /data
+ENV HOME=/home/proxyapp \
+    CLAUDE_CONFIG_DIR=/data/.claude \
+    HOST=0.0.0.0 \
+    PORT=3456
+
+EXPOSE 3456
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3456)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "dist/server/standalone.js"]


### PR DESCRIPTION
## What

Adds a production-ready Dockerfile (+ .dockerignore) so the proxy can run as a container service (Docker Compose, EasyPanel, Kubernetes, ...).

**Design:**
- Multi-stage build on `node:22-slim`: builder compiles TypeScript, runtime ships only production deps
- Claude Code CLI preinstalled globally (the proxy wraps it as a subprocess)
- Non-root user `proxyapp` (node:*-slim base images already ship a system user named `proxy`, hence the distinct name)
- **Credentials persistence:** `CLAUDE_CONFIG_DIR=/data/.claude` – mounting a volume on `/data` keeps OAuth tokens across restarts/redeploys (the CLI refreshes tokens in place)
- Healthcheck against `/health`
- `HOST=0.0.0.0` / `PORT=3456` presets for container networking

**Context:** PR #9 (Docker CI workflow) was closed without merge – this PR is different in scope: it ships the Dockerfile itself, no CI changes.

**Tested:** Running in production on an EasyPanel (Docker Swarm) host – build, healthchecks, volume persistence across redeploys all verified live.

Note: pairs naturally with the auth/.env PR I'll open next (the proxy currently has no request authentication, which matters once it listens on a routable address).