### PR TITLE
feat: API key auth, .env config, admin relogin & usage endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Claude Max API Proxy - Konfiguration
+# Diese Datei nach .env kopieren und anpassen (bei lokalem Betrieb).
+# In EasyPanel: die Variablen direkt im Dienst als Environment setzen.
+
+# ------------------------------------------------------------------
+# API-Key fuer den Proxy (OpenAI-kompatibel, als Bearer-Token).
+# Alle Requests brauchen:  Authorization: Bearer <PROXY_API_KEY>
+#
+# Wird nichts gesetzt, generiert der Server beim Start einen
+# zufaelligen Key und gibt ihn einmalig im Log aus.
+# "off" deaktiviert die Auth komplett (NUR lokal entwickeln!).
+# ------------------------------------------------------------------
+PROXY_API_KEY=hier-sicheren-key-eintragen
+
+# ------------------------------------------------------------------
+# Admin-Key fuer /admin/* (Re-Login-Flow). Separater Key empfohlen,
+# damit normale API-Nutzer keinen Relogin ausloesen koennen.
+# Wenn nicht gesetzt, gilt PROXY_API_KEY auch fuer Admin-Endpunkte.
+# ------------------------------------------------------------------
+# PROXY_ADMIN_KEY=noch-sichereren-admin-key-eintragen
+
+# Port, auf dem der Server lauscht (Default: 3456)
+PORT=3456
+
+# Host-Binding:
+#   127.0.0.1  = nur lokal (Default, sicher fuer Entwicklung)
+#   0.0.0.0    = alle Interfaces (im Docker-Container zwingend noetig)
+HOST=127.0.0.1
+
+# Debug-Logging aktivieren (Request-Bodies werden mitgeloggt)
+# DEBUG=1

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -1,0 +1,298 @@
+/**
+ * Admin endpoints: in-container re-authentication of the Claude CLI.
+ *
+ * Flow (no container/SSH access needed):
+ *   1. POST /admin/relogin/start   → spawns `claude auth login`
+ *      inside the container, parses the OAuth URL from its output and
+ *      returns it. The admin opens the URL in any browser and authorizes.
+ *   2. POST /admin/relogin/complete { code } → pastes the authorization
+ *      code back into the waiting CLI process via stdin.
+ *   3. GET  /admin/relogin/status  → poll the current state.
+ *
+ * The CLI writes fresh credentials to $CLAUDE_CONFIG_DIR (~/.claude),
+ * which lives on the persistent /data volume - so the new tokens survive
+ * container restarts and redeploys.
+ *
+ * All routes are protected by adminAuth (PROXY_ADMIN_KEY, falling back to
+ * PROXY_API_KEY).
+ */
+
+import { Router } from "express";
+import { spawn, execFile, ChildProcess } from "child_process";
+
+type ReloginState = "idle" | "awaiting_code" | "success" | "failed";
+
+interface ReloginSession {
+  state: ReloginState;
+  url: string | null;
+  detail: string | null;
+  startedAt: number;
+  proc: ChildProcess | null;
+  buffer: string;
+}
+
+const SESSION_TIMEOUT_MS = 10 * 60 * 1000; // 10 min to complete the flow
+
+let session: ReloginSession | null = null;
+
+function resetSession(): void {
+  if (session?.proc) {
+    session.proc.kill("SIGTERM");
+  }
+  session = null;
+}
+
+function isExpired(s: ReloginSession): boolean {
+  return Date.now() - s.startedAt > SESSION_TIMEOUT_MS;
+}
+
+/**
+ * Try to extract the OAuth authorize URL from CLI output.
+ * The CLI prints something like "Open this URL: https://claude.ai/oauth/authorize?..."
+ */
+function extractUrl(text: string): string | null {
+  const m = text.match(/https:\/\/[^\s"']*(?:oauth|authorize|login)[^\s"']*/i);
+  return m ? m[0] : null;
+}
+
+export function createAdminRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /admin/relogin/start
+   * Starts `claude auth login` in the container and returns
+   * the URL the admin must open in a browser.
+   */
+  router.post("/relogin/start", (_req, res) => {
+    if (session && !isExpired(session) && session.state === "awaiting_code") {
+      // A flow is already waiting - return its URL again (idempotent for retries)
+      res.json({ state: session.state, url: session.url, note: "Flow already in progress" });
+      return;
+    }
+    resetSession();
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn("claude", ["auth", "login"], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err) {
+      res.status(500).json({
+        error: { message: `Failed to spawn claude CLI: ${String(err)}`, type: "server_error", code: null },
+      });
+      return;
+    }
+
+    session = {
+      state: "awaiting_code",
+      url: null,
+      detail: null,
+      startedAt: Date.now(),
+      proc,
+      buffer: "",
+    };
+
+    const onData = (chunk: Buffer) => {
+      if (!session) return;
+      session.buffer += chunk.toString();
+      if (!session.url) {
+        session.url = extractUrl(session.buffer);
+        if (session.url) {
+          console.log("[Admin] Relogin URL ready");
+        }
+      }
+    };
+    proc.stdout?.on("data", onData);
+    proc.stderr?.on("data", onData);
+
+    proc.on("close", (code) => {
+      if (!session) return;
+      if (session.state === "success") return; // already completed via /complete
+      session.state = code === 0 ? "success" : "failed";
+      session.detail = `claude auth login exited with code ${code}`;
+      session.proc = null;
+      console.log(`[Admin] Relogin process closed: ${session.state}`);
+    });
+
+    // Give the CLI a moment to print the URL before responding
+    const deadline = Date.now() + 8000;
+    const poll = setInterval(() => {
+      if (!session) {
+        clearInterval(poll);
+        return;
+      }
+      if (session.url || Date.now() > deadline) {
+        clearInterval(poll);
+        if (session.url) {
+          res.json({
+            state: session.state,
+            url: session.url,
+            instructions:
+              "Open the URL in a browser, authorize, then POST the returned code to /admin/relogin/complete",
+          });
+        } else {
+          res.status(202).json({
+            state: session.state,
+            url: null,
+            note: "CLI started but has not printed a URL yet - poll GET /admin/relogin/status",
+          });
+        }
+      }
+    }, 250);
+  });
+
+  /**
+   * POST /admin/relogin/complete { code: "..." }
+   * Feeds the authorization code into the waiting CLI process.
+   */
+  router.post("/relogin/complete", (req, res) => {
+    if (!session || session.state !== "awaiting_code" || !session.proc) {
+      res.status(409).json({
+        error: {
+          message: "No login flow in progress. Call POST /admin/relogin/start first.",
+          type: "invalid_request_error",
+          code: "no_flow",
+        },
+      });
+      return;
+    }
+    if (isExpired(session)) {
+      resetSession();
+      res.status(410).json({
+        error: {
+          message: "Login flow timed out (10 min). Start again with POST /admin/relogin/start.",
+          type: "invalid_request_error",
+          code: "flow_expired",
+        },
+      });
+      return;
+    }
+
+    const code = (req.body?.code || "").toString().trim();
+    if (!code) {
+      res.status(400).json({
+        error: { message: "Missing 'code' in request body.", type: "invalid_request_error", code: "missing_code" },
+      });
+      return;
+    }
+
+    const proc = session.proc;
+    const current = session;
+
+    const timeout = setTimeout(() => {
+      if (session === current && current.state === "awaiting_code") {
+        res.status(202).json({ state: current.state, note: "Code submitted, waiting for CLI to finish - poll /admin/relogin/status" });
+      }
+    }, 15000);
+
+    const onClose = (exitCode: number | null) => {
+      clearTimeout(timeout);
+      current.state = exitCode === 0 ? "success" : "failed";
+      current.detail = exitCode === 0
+        ? "Login successful - credentials written to the persistent volume."
+        : `Login failed (exit code ${exitCode}). Output: ${current.buffer.slice(-500)}`;
+      current.proc = null;
+      console.log(`[Admin] Relogin completed: ${current.state}`);
+      if (!res.headersSent) {
+        res.status(exitCode === 0 ? 200 : 502).json({ state: current.state, detail: current.detail });
+      }
+      // Clean up the session after responding - on success the CLI output may
+      // contain account details we don't want to keep in memory
+      if (session === current) {
+        session = null;
+      }
+    };
+
+    proc.once("close", onClose);
+    proc.stdin?.write(code + "\n");
+    proc.stdin?.end();
+  });
+
+  /**
+   * GET /admin/relogin/status
+   */
+  router.get("/relogin/status", (_req, res) => {
+    if (!session) {
+      res.json({ state: "idle" });
+      return;
+    }
+    res.json({
+      state: session.state,
+      url: session.url,
+      detail: session.detail,
+      expiresIn: Math.max(0, SESSION_TIMEOUT_MS - (Date.now() - session.startedAt)),
+    });
+  });
+
+  /**
+   * POST /admin/relogin/cancel
+   */
+  router.post("/relogin/cancel", (_req, res) => {
+    resetSession();
+    res.json({ state: "idle" });
+  });
+
+  /**
+   * GET /admin/usage
+   * Subscription usage as reported by the CLI itself ("claude --print /usage").
+   * Answers directly from the CLI, costs no API tokens. Cached for 60s.
+   */
+  router.get("/usage", (_req, res) => {
+    const now = Date.now();
+    if (usageCache && now - usageCache.at < 60_000) {
+      res.json({ ...usageCache.data, cached: true });
+      return;
+    }
+
+    execFile(
+      "claude",
+      ["--print", "/usage"],
+      { timeout: 20_000, maxBuffer: 64 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          res.status(502).json({
+            error: {
+              message: `Usage query failed: ${stderr?.toString().trim() || err.message}`,
+              type: "server_error",
+              code: null,
+            },
+          });
+          return;
+        }
+        res.json({ ...parseUsage(stdout.toString()), cached: false });
+      }
+    );
+  });
+
+  return router;
+}
+
+let usageCache: { at: number; data: Record<string, unknown> } | null = null;
+
+/**
+ * Parse the plain-text output of "claude --print /usage" into structured data.
+ * Format (CLI 2.1.x), lines like:
+ *   Current session: 3% used · resets Aug 16, 5:50pm (UTC)
+ *   Current week (all models): 7% used · resets Aug 19, 9am (UTC)
+ */
+function parseUsage(text: string): Record<string, unknown> {
+  const result: Record<string, unknown> = { raw: text.trim() };
+  const lineRe =
+    /^(Current session|Current week(?: \(([^)]+)\))?)\s*:\s*(\d+)% used(?:\s*·\s*resets (.+))?$/i;
+
+  for (const line of text.split("\n")) {
+    const m = line.trim().match(lineRe);
+    if (!m) continue;
+    const scope = m[2] ? m[2].toLowerCase().replace(/\s+/g, "_") : null;
+    const key = m[1].toLowerCase().startsWith("current session")
+      ? "session"
+      : scope
+        ? `week_${scope}`
+        : "week_all_models";
+    result[key] = {
+      percent_used: Number(m[3]),
+      ...(m[4] ? { resets: m[4].trim() } : {}),
+    };
+  }
+  return result;
+}

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -259,7 +259,9 @@ export function createAdminRouter(): Router {
           });
           return;
         }
-        res.json({ ...parseUsage(stdout.toString()), cached: false });
+        const data = parseUsage(stdout.toString());
+        usageCache = { at: Date.now(), data };
+        res.json({ ...data, cached: false });
       }
     );
   });

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,160 @@
+/**
+ * API Key Authentication Middleware
+ *
+ * Protects the proxy endpoints with a Bearer token (OpenAI style).
+ * Configure via PROXY_API_KEY environment variable.
+ *
+ * Behavior:
+ * - If PROXY_API_KEY is not set, a secure random key is generated at
+ *   startup and printed to the logs (auth stays ON).
+ * - Set PROXY_API_KEY=off to explicitly disable authentication
+ *   (only recommended for local development).
+ * - /health is always public so uptime checks keep working.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import { randomBytes, timingSafeEqual } from "crypto";
+
+let configuredKey: string | null = null;
+let authEnabled = false;
+
+/**
+ * Initialize the API key from the environment.
+ * Returns a status object so the caller can log what happened.
+ */
+export function initApiKey(): {
+  enabled: boolean;
+  generated: boolean;
+  key: string | null;
+} {
+  const raw = process.env.PROXY_API_KEY?.trim();
+
+  if (raw && raw.toLowerCase() === "off") {
+    configuredKey = null;
+    authEnabled = false;
+    return { enabled: false, generated: false, key: null };
+  }
+
+  if (raw) {
+    configuredKey = raw;
+    authEnabled = true;
+    return { enabled: true, generated: false, key: raw };
+  }
+
+  // No key configured: generate one instead of running unprotected
+  const generated = `sk-proxy-${randomBytes(24).toString("hex")}`;
+  configuredKey = generated;
+  authEnabled = true;
+  return { enabled: true, generated: true, key: generated };
+}
+
+export function isAuthEnabled(): boolean {
+  return authEnabled;
+}
+
+let configuredAdminKey: string | null = null;
+
+/**
+ * Initialize the optional admin key (PROXY_ADMIN_KEY).
+ * Falls back to the regular API key when no dedicated admin key is set.
+ * Returns the same shape as initApiKey for startup logging.
+ */
+export function initAdminKey(): { configured: boolean; fallback: boolean } {
+  const raw = process.env.PROXY_ADMIN_KEY?.trim();
+  if (raw) {
+    configuredAdminKey = raw;
+    return { configured: true, fallback: false };
+  }
+  return { configured: false, fallback: true };
+}
+
+/**
+ * Express middleware for /admin/* routes.
+ * Requires PROXY_ADMIN_KEY; if unset, the regular PROXY_API_KEY is accepted.
+ * If neither exists, admin routes are locked (403).
+ */
+export function adminAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const effective = configuredAdminKey || configuredKey;
+
+  if (!effective) {
+    res.status(403).json({
+      error: {
+        message:
+          "Admin endpoints are locked. Set PROXY_ADMIN_KEY (or PROXY_API_KEY) to enable them.",
+        type: "invalid_request_error",
+        code: "admin_locked",
+      },
+    });
+    return;
+  }
+
+  const header = req.headers.authorization;
+  const token = header?.startsWith("Bearer ") ? header.slice(7).trim() : null;
+
+  if (!token || !safeEqual(token, effective)) {
+    res.status(401).json({
+      error: {
+        message: "Invalid admin key.",
+        type: "invalid_request_error",
+        code: "invalid_admin_key",
+      },
+    });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Constant-time string comparison to avoid timing attacks.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Express middleware enforcing the API key on all routes except /health.
+ */
+export function apiKeyAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!authEnabled || !configuredKey) {
+    next();
+    return;
+  }
+
+  // Health check stays public (uptime monitors, EasyPanel checks)
+  // Admin routes handle their own (stricter) auth via adminAuth
+  if (req.path === "/health" || req.path.startsWith("/admin")) {
+    next();
+    return;
+  }
+
+  const header = req.headers.authorization;
+  const token = header?.startsWith("Bearer ") ? header.slice(7).trim() : null;
+
+  if (!token || !safeEqual(token, configuredKey)) {
+    res.status(401).json({
+      error: {
+        message:
+          "Invalid or missing API key. Provide it as 'Authorization: Bearer <key>'.",
+        type: "invalid_request_error",
+        code: "invalid_api_key",
+      },
+    });
+    return;
+  }
+
+  next();
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,8 @@
 import express, { Express, Request, Response, NextFunction } from "express";
 import { createServer, Server } from "http";
 import { handleChatCompletions, handleModels, handleHealth } from "./routes.js";
+import { apiKeyAuth, adminAuth } from "./auth.js";
+import { createAdminRouter } from "./admin.js";
 
 export interface ServerConfig {
   port: number;
@@ -69,6 +71,12 @@ function createApp(): Express {
   app.options("*", (_req: Request, res: Response) => {
     res.sendStatus(200);
   });
+
+  // API key authentication (protects all routes except /health, see auth.ts)
+  app.use(apiKeyAuth);
+
+  // Admin routes (relogin flow) - separate key requirement
+  app.use("/admin", adminAuth, createAdminRouter());
 
   // Routes
   app.get("/health", handleHealth);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -220,8 +220,8 @@ async function handleStreamingResponse(
       // CLI surfaces auth failures as plain text on stdout in some failure
       // modes - replace with actionable guidance
       if (text && subprocess.hasAuthError()) {
-        text = AUTH_EXPIRED_MESSAGE;
-        isComplete = true;
+        // error/close handlers emit the guidance exactly once
+        return;
       }
       if (text && !res.writableEnded) {
         const chunk = {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -16,6 +16,41 @@ import { getSession, setSession, clearSession } from "../subprocess/session-stor
 import type { OpenAIChatRequest, OpenAIToolCall } from "../types/openai.js";
 import type { ClaudeCliAssistant, ClaudeCliResult, ClaudeCliStreamEvent } from "../types/claude-cli.js";
 
+/**
+ * User-facing guidance when the Claude CLI's OAuth session has expired.
+ * Returned as a normal assistant message instead of a raw 500 so the user
+ * sees actionable steps directly in their chat client.
+ */
+const AUTH_EXPIRED_MESSAGE = [
+  "Die Claude-Anmeldung auf dem Server ist abgelaufen – Anfragen sind derzeit nicht moeglich.",
+  "",
+  "Neuanmeldung direkt ueber die Admin-API (kein Server-Zugriff noetig):",
+  "1. `POST /admin/relogin/start` (mit Admin-Key) – die Antwort enthaelt eine Login-URL.",
+  "2. URL im Browser oeffnen und die Anmeldung bestaetigen.",
+  "3. Den angezeigten Code per `POST /admin/relogin/complete` zurueckschicken.",
+  "4. Danach funktioniert dieser Chat sofort wieder – die neuen Tokens liegen persistent im Volume.",
+  "",
+  "Details: siehe DOCKER.md, Abschnitt 'Re-Login ohne Container-Zugriff'.",
+].join("\n");
+
+/** Build an OpenAI-style assistant message body (non-streaming) */
+function authExpiredResponse(requestId: string, model: string) {
+  return {
+    id: `chatcmpl-${requestId}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: AUTH_EXPIRED_MESSAGE },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
+
 interface SessionContext {
   sessionKey: string | undefined;
   resume: boolean;
@@ -181,7 +216,13 @@ async function handleStreamingResponse(
     // Handle streaming content deltas
     subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
       const delta = event.event.delta;
-      const text = (delta?.type === "text_delta" && delta.text) || "";
+      let text = (delta?.type === "text_delta" && delta.text) || "";
+      // CLI surfaces auth failures as plain text on stdout in some failure
+      // modes - replace with actionable guidance
+      if (text && subprocess.hasAuthError()) {
+        text = AUTH_EXPIRED_MESSAGE;
+        isComplete = true;
+      }
       if (text && !res.writableEnded) {
         const chunk = {
           id: `chatcmpl-${requestId}`,
@@ -309,6 +350,23 @@ async function handleStreamingResponse(
       if (sessionCtx.resume && sessionCtx.sessionKey) {
         clearSession(sessionCtx.sessionKey);
       }
+      if (subprocess.hasAuthError()) {
+        console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+        if (!res.writableEnded) {
+          const chunk = {
+            id: `chatcmpl-${requestId}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: lastModel,
+            choices: [{ index: 0, delta: { role: "assistant", content: AUTH_EXPIRED_MESSAGE }, finish_reason: null }],
+          };
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          res.write("data: [DONE]\n\n");
+          res.end();
+        }
+        resolve();
+        return;
+      }
       if (!res.writableEnded) {
         res.write(
           `data: ${JSON.stringify({
@@ -391,6 +449,12 @@ async function handleNonStreamingResponse(
       if (sessionCtx.resume && sessionCtx.sessionKey) {
         clearSession(sessionCtx.sessionKey);
       }
+      if (subprocess.hasAuthError()) {
+        console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+        res.json(authExpiredResponse(requestId, "claude-sonnet-4"));
+        resolve();
+        return;
+      }
       res.status(500).json({
         error: {
           message: error.message,
@@ -412,13 +476,18 @@ async function handleNonStreamingResponse(
           clearSession(sessionCtx.sessionKey);
         }
         if (!res.headersSent) {
-          res.status(500).json({
-            error: {
-              message: `Claude CLI exited with code ${code} without response`,
-              type: "server_error",
-              code: null,
-            },
-          });
+          if (subprocess.hasAuthError()) {
+            console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+            res.json(authExpiredResponse(requestId, "claude-sonnet-4"));
+          } else {
+            res.status(500).json({
+              error: {
+                message: `Claude CLI exited with code ${code} without response`,
+                type: "server_error",
+                code: null,
+              },
+            });
+          }
         }
       }
       resolve();

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -8,8 +8,41 @@
  *   node dist/server/standalone.js [port]
  */
 
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { startServer, stopServer } from "./index.js";
-import { verifyClaude, verifyAuth } from "../subprocess/manager.js";
+import { verifyClaude } from "../subprocess/manager.js";
+import { initApiKey, initAdminKey } from "./auth.js";
+
+/**
+ * Minimal .env loader: only sets variables that are not already present in
+ * process.env, so container/CI environment variables always win.
+ * No external dependency needed.
+ */
+function loadEnvFile(): void {
+  let content: string;
+  try {
+    content = readFileSync(".env", "utf8");
+  } catch {
+    return; // no .env file - fine
+  }
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
 
 const DEFAULT_PORT = 3456;
 
@@ -17,11 +50,40 @@ async function main(): Promise<void> {
   console.log("Claude Code CLI Provider - Standalone Server");
   console.log("============================================\n");
 
-  // Parse port from command line
-  const port = parseInt(process.argv[2] || String(DEFAULT_PORT), 10);
+  loadEnvFile();
+
+  // Parse port: CLI argument > PORT env var > default
+  const port = parseInt(
+    process.argv[2] || process.env.PORT || String(DEFAULT_PORT),
+    10
+  );
   if (isNaN(port) || port < 1 || port > 65535) {
-    console.error(`Invalid port: ${process.argv[2]}`);
+    console.error(`Invalid port: ${process.argv[2] || process.env.PORT}`);
     process.exit(1);
+  }
+
+  // Host binding: 0.0.0.0 is required inside Docker containers,
+  // 127.0.0.1 is the safer default for local development.
+  const host = process.env.HOST || "127.0.0.1";
+
+  // API key authentication
+  const keyStatus = initApiKey();
+  if (keyStatus.enabled && keyStatus.generated) {
+    console.log("[Auth] No PROXY_API_KEY configured - generated a random one:");
+    console.log(`[Auth]   ${keyStatus.key}`);
+    console.log("[Auth] Set PROXY_API_KEY in your environment to use your own.\n");
+  } else if (keyStatus.enabled) {
+    console.log("[Auth] API key authentication: ENABLED\n");
+  } else {
+    console.log("[Auth] WARNING: API key authentication DISABLED (PROXY_API_KEY=off)");
+    console.log("[Auth] Only do this for local development!\n");
+  }
+
+  const adminStatus = initAdminKey();
+  if (adminStatus.configured) {
+    console.log("[Auth] Admin endpoints (/admin/*): ENABLED (dedicated PROXY_ADMIN_KEY)");
+  } else if (keyStatus.enabled) {
+    console.log("[Auth] Admin endpoints (/admin/*): ENABLED (falls back to PROXY_API_KEY)");
   }
 
   // Verify Claude CLI
@@ -33,19 +95,30 @@ async function main(): Promise<void> {
   }
   console.log(`  Claude CLI: ${cliCheck.version || "OK"}`);
 
-  // Verify authentication
+  // Check for credentials. The CLI can also store them in the OS keychain,
+  // which we can't inspect - so a missing config dir is a warning, not fatal.
   console.log("Checking authentication...");
-  const authCheck = await verifyAuth();
-  if (!authCheck.ok) {
-    console.error(`Error: ${authCheck.error}`);
-    console.error("Please run: claude auth login");
-    process.exit(1);
+  const configDir = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  let hasCredentials = false;
+  try {
+    hasCredentials =
+      existsSync(configDir) && readdirSync(configDir).some((f) => f.endsWith(".json"));
+  } catch {
+    hasCredentials = false;
   }
-  console.log("  Authentication: OK\n");
+  if (hasCredentials) {
+    console.log("  Credentials: found\n");
+  } else {
+    console.log("  Credentials: NOT FOUND");
+    console.log("  The server will start anyway, but chat requests will return a");
+    console.log("  guidance message until you log in via the admin API:");
+    console.log("    POST /admin/relogin/start  ->  open URL in browser");
+    console.log("    POST /admin/relogin/complete  ->  submit the code\n");
+  }
 
   // Start server
   try {
-    await startServer({ port });
+    await startServer({ port, host });
     console.log("\nServer ready. Test with:");
     console.log(`  curl -X POST http://localhost:${port}/v1/chat/completions \\`);
     console.log(`    -H "Content-Type: application/json" \\`);

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -98,11 +98,14 @@ async function main(): Promise<void> {
   // Check for credentials. The CLI can also store them in the OS keychain,
   // which we can't inspect - so a missing config dir is a warning, not fatal.
   console.log("Checking authentication...");
-  const configDir = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  const home = process.env.HOME || "";
+  const configDir = process.env.CLAUDE_CONFIG_DIR || (home ? `${home}/.claude` : "");
   let hasCredentials = false;
   try {
     hasCredentials =
-      existsSync(configDir) && readdirSync(configDir).some((f) => f.endsWith(".json"));
+      configDir !== "" &&
+      existsSync(configDir) &&
+      readdirSync(configDir).some((f) => f.endsWith(".json"));
   } catch {
     hasCredentials = false;
   }

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -27,6 +27,30 @@ import {
 } from "../types/claude-cli.js";
 import type { ClaudeModel } from "../adapter/openai-to-cli.js";
 
+const DEFAULT_TIMEOUT = 900000; // 15 minutes
+
+/**
+ * Detect authentication/authorization failures from CLI stderr or exit codes.
+ * The CLI surfaces expired OAuth tokens as 401/authentication_error text on
+ * stderr (there is no structured error type in stream-json), so we match the
+ * known signatures.
+ */
+export function isAuthError(stderr: string, exitCode: number | null): boolean {
+  if (exitCode === 401) return true;
+  const text = stderr.toLowerCase();
+  return (
+    text.includes("authentication_error") ||
+    text.includes("authentication failed") ||
+    (text.includes("401") && text.includes("unauthorized")) ||
+    text.includes("oauth token has expired") ||
+    text.includes("token expired") ||
+    text.includes("invalid oauth token") ||
+    (text.includes("not logged in") && text.includes("claude")) ||
+    text.includes("please run /login") ||
+    text.includes("please run claude auth login")
+  );
+}
+
 export interface SubprocessOptions {
   model: ClaudeModel;
   sessionId?: string;
@@ -36,16 +60,6 @@ export interface SubprocessOptions {
   timeout?: number;
 }
 
-export interface SubprocessEvents {
-  message: (msg: ClaudeCliMessage) => void;
-  assistant: (msg: ClaudeCliAssistant) => void;
-  result: (result: ClaudeCliResult) => void;
-  error: (error: Error) => void;
-  close: (code: number | null) => void;
-  raw: (line: string) => void;
-}
-
-const DEFAULT_TIMEOUT = 900000; // 15 minutes
 
 /**
  * System prompt appended to Claude CLI to map OpenClaw tool names to Claude Code equivalents.
@@ -194,6 +208,8 @@ function killProcessTree(
 export class ClaudeSubprocess extends EventEmitter {
   private process: ChildProcess | null = null;
   private buffer: string = "";
+  private stderrBuffer: string = "";
+  private exitCode: number | null = null;
   private timeoutId: NodeJS.Timeout | null = null;
   private isKilled: boolean = false;
 
@@ -255,10 +271,12 @@ export class ClaudeSubprocess extends EventEmitter {
           this.processBuffer();
         });
 
-        // Capture stderr for debugging
+        // Capture stderr for debugging and auth-error detection
         this.process.stderr?.on("data", (chunk: Buffer) => {
           const errorText = chunk.toString().trim();
           if (errorText) {
+            // Keep a bounded tail (4 KB) - enough for error signatures
+            this.stderrBuffer = (this.stderrBuffer + errorText + "\n").slice(-4096);
             // Don't emit as error unless it's actually an error
             // Claude CLI may write debug info to stderr
             if (process.env.DEBUG_SUBPROCESS) {
@@ -269,6 +287,7 @@ export class ClaudeSubprocess extends EventEmitter {
 
         // Handle process close
         this.process.on("close", (code) => {
+          this.exitCode = code;
           if (process.env.DEBUG_SUBPROCESS) {
             console.error(`[Subprocess] Process closed with code: ${code}`);
           }
@@ -388,6 +407,14 @@ export class ClaudeSubprocess extends EventEmitter {
       this.clearTimeout();
       this.isKilled = killProcessTree(this.process, signal);
     }
+  }
+
+  /**
+   * True if the subprocess failed due to an authentication problem
+   * (expired OAuth token, logged out). Check after "close"/"error".
+   */
+  hasAuthError(): boolean {
+    return isAuthError(this.stderrBuffer, this.exitCode);
   }
 
   /**


### PR DESCRIPTION
## What

Adds the security & operations layer needed to run the proxy on a routable address (server deployments). Everything here is **running in production** on my EasyPanel host.

**API key authentication** (`src/server/auth.ts`)
- `PROXY_API_KEY` env → OpenAI-style `Authorization: Bearer <key>` on all endpoints except `/health`
- Timing-safe comparison; **generates a random key at startup when unset** (never runs unprotected by accident); `off` disables explicitly for local dev

**Configuration**
- Minimal `.env` loader (no new dependency; existing env vars take precedence), `PORT`/`HOST` env vars, `.env.example` documenting everything

**Admin endpoints** (`src/server/admin.ts`, separate `PROXY_ADMIN_KEY`, falls back to `PROXY_API_KEY`, 403 when neither set)
- `POST /admin/relogin/start|complete|status|cancel` – runs `claude auth login` inside the deployment, returns the OAuth URL, feeds the authorization code back via stdin. **Re-authentication without SSH/container access.** Verified live against Claude CLI 2.1.233 (plain `auth login` is headless-friendly: prints the URL, waits for the code on stdin).
- `GET /admin/usage` – structured subscription usage via `claude --print /usage` (no API cost, 60s cache)

**Runtime auth-failure detection**
- CLI surfaces expired OAuth only as stderr text/exit code – matched against known signatures (bounded 4 KB stderr tail)
- Expired sessions return an **actionable in-chat guidance message** (streaming + non-streaming) instead of a raw 500
- Startup logs the real credential state instead of the previous always-OK stub

**Note:** touches `routes.ts`/`manager.ts` – the follow-up PR (vision/effort/cache metrics) is stacked on this one; merging in order avoids conflicts.