### PR TITLE
feat: vision support, reasoning effort pass-through, cache metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Claude Max API Proxy - Konfiguration
+# Diese Datei nach .env kopieren und anpassen (bei lokalem Betrieb).
+# In EasyPanel: die Variablen direkt im Dienst als Environment setzen.
+
+# ------------------------------------------------------------------
+# API-Key fuer den Proxy (OpenAI-kompatibel, als Bearer-Token).
+# Alle Requests brauchen:  Authorization: Bearer <PROXY_API_KEY>
+#
+# Wird nichts gesetzt, generiert der Server beim Start einen
+# zufaelligen Key und gibt ihn einmalig im Log aus.
+# "off" deaktiviert die Auth komplett (NUR lokal entwickeln!).
+# ------------------------------------------------------------------
+PROXY_API_KEY=hier-sicheren-key-eintragen
+
+# ------------------------------------------------------------------
+# Admin-Key fuer /admin/* (Re-Login-Flow). Separater Key empfohlen,
+# damit normale API-Nutzer keinen Relogin ausloesen koennen.
+# Wenn nicht gesetzt, gilt PROXY_API_KEY auch fuer Admin-Endpunkte.
+# ------------------------------------------------------------------
+# PROXY_ADMIN_KEY=noch-sichereren-admin-key-eintragen
+
+# Port, auf dem der Server lauscht (Default: 3456)
+PORT=3456
+
+# Host-Binding:
+#   127.0.0.1  = nur lokal (Default, sicher fuer Entwicklung)
+#   0.0.0.0    = alle Interfaces (im Docker-Container zwingend noetig)
+HOST=127.0.0.1
+
+# Debug-Logging aktivieren (Request-Bodies werden mitgeloggt)
+# DEBUG=1

--- a/src/adapter/cli-to-openai.ts
+++ b/src/adapter/cli-to-openai.ts
@@ -101,6 +101,13 @@ export function cliResultToOpenai(
       completion_tokens: result.usage?.output_tokens || 0,
       total_tokens:
         (result.usage?.input_tokens || 0) + (result.usage?.output_tokens || 0),
+      // Prompt caching is automatic in Claude Code - surface the metrics
+      ...(result.usage?.cache_read_input_tokens
+        ? { cache_read_input_tokens: result.usage.cache_read_input_tokens }
+        : {}),
+      ...(result.usage?.cache_creation_input_tokens
+        ? { cache_creation_input_tokens: result.usage.cache_creation_input_tokens }
+        : {}),
     },
   };
 }
@@ -111,6 +118,9 @@ export function cliResultToOpenai(
  */
 function normalizeModelName(model: string | undefined): string {
   if (!model) return "claude-sonnet-4";
+  // Keep the major version visible: "claude-opus-5-..." -> "claude-opus-5"
+  const m = model.match(/claude-(opus|sonnet|haiku)-(\d+)/);
+  if (m) return `claude-${m[1]}-${m[2]}`;
   if (model.includes("opus")) return "claude-opus-4";
   if (model.includes("sonnet")) return "claude-sonnet-4";
   if (model.includes("haiku")) return "claude-haiku-4";

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -4,12 +4,37 @@
 
 import type { OpenAIChatRequest, OpenAIContentBlock } from "../types/openai.js";
 
+export type ClaudeEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
 export type ClaudeModel = "opus" | "sonnet" | "haiku";
+
+export interface CliImage {
+  /** MIME type, e.g. image/png */
+  mimeType: string;
+  /** Raw base64 payload (without data URL prefix) */
+  data: string;
+  /** Original remote URL if the client sent one (no base64 copy kept) */
+  sourceUrl?: string;
+}
 
 export interface CliInput {
   prompt: string;
   model: ClaudeModel;
   sessionId?: string;
+  effort?: ClaudeEffort;
+  /** Images extracted from image_url content blocks, to be materialized as temp files */
+  images?: CliImage[];
+}
+
+const EFFORT_LEVELS: ClaudeEffort[] = ["low", "medium", "high", "xhigh", "max"];
+
+/**
+ * Normalize effort from an OpenAI-compatible request (reasoning_effort or effort).
+ * Unknown values are ignored so the CLI default applies.
+ */
+export function extractEffort(request: OpenAIChatRequest): ClaudeEffort | undefined {
+  const raw = (request.reasoning_effort || request.effort || "").toLowerCase().trim();
+  return (EFFORT_LEVELS as string[]).includes(raw) ? (raw as ClaudeEffort) : undefined;
 }
 
 const MODEL_MAP: Record<string, ClaudeModel> = {
@@ -64,10 +89,33 @@ function extractText(content: string | OpenAIContentBlock[]): string {
   if (Array.isArray(content)) {
     return content
       .filter((block) => block.type === "text" || block.type === "input_text")
-      .map((block) => block.text)
+      .map((block) => (block as { text: string }).text)
       .join("\n");
   }
   return String(content || "");
+}
+
+/**
+ * Extract images from OpenAI image_url content blocks.
+ * Data URLs (what OpenWebUI sends for uploads) are decoded to base64 payloads;
+ * remote http(s) URLs are passed through as sourceUrl for later download.
+ */
+export function extractImages(messages: OpenAIChatRequest["messages"]): CliImage[] {
+  const images: CliImage[] = [];
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block.type !== "image_url" || !block.image_url?.url) continue;
+      const url = block.image_url.url;
+      const dataUrl = url.match(/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/);
+      if (dataUrl) {
+        images.push({ mimeType: dataUrl[1], data: dataUrl[2] });
+      } else if (/^https?:\/\//.test(url)) {
+        images.push({ mimeType: "", data: "", sourceUrl: url });
+      }
+    }
+  }
+  return images;
 }
 
 /**
@@ -138,10 +186,13 @@ export function messagesToPrompt(
  * Convert OpenAI chat request to CLI input format
  */
 export function openaiToCli(request: OpenAIChatRequest): CliInput {
+  const images = extractImages(request.messages);
   return {
     prompt: messagesToPrompt(request.messages),
     model: extractModel(request.model),
     sessionId: request.user, // Use OpenAI's user field for session mapping
+    effort: extractEffort(request),
+    ...(images.length > 0 ? { images } : {}),
   };
 }
 
@@ -159,11 +210,15 @@ export function openaiToCliDelta(
     .slice(sinceIndex)
     .filter((m) => m.role !== "assistant");
 
+  const source = newMessages.length ? newMessages : request.messages;
+  const images = extractImages(source);
   return {
     // Fallback to full history if nothing new was found (shouldn't happen,
     // but never send an empty prompt to the CLI)
-    prompt: messagesToPrompt(newMessages.length ? newMessages : request.messages),
+    prompt: messagesToPrompt(source),
     model: extractModel(request.model),
     sessionId: request.user,
+    effort: extractEffort(request),
+    ...(images.length > 0 ? { images } : {}),
   };
 }

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -2,7 +2,7 @@
  * Converts OpenAI chat request format to Claude CLI input
  */
 
-import type { OpenAIChatRequest, OpenAIContentBlock } from "../types/openai.js";
+import type { OpenAIChatRequest, OpenAIContentBlock, OpenAIToolDefinition } from "../types/openai.js";
 
 export type ClaudeEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -24,6 +24,10 @@ export interface CliInput {
   effort?: ClaudeEffort;
   /** Images extracted from image_url content blocks, to be materialized as temp files */
   images?: CliImage[];
+  /** Client-side tool definitions from the OpenAI request */
+  tools?: OpenAIToolDefinition[];
+  /** True when the client sent tools - the CLI's built-in tools must be disabled then */
+  hasClientTools?: boolean;
 }
 
 const EFFORT_LEVELS: ClaudeEffort[] = ["low", "medium", "high", "xhigh", "max"];
@@ -82,7 +86,10 @@ export function extractModel(model: string): ClaudeModel {
  *   - A plain string: "Hello"
  *   - An array of content blocks: [{"type": "text", "text": "Hello"}]
  */
-function extractText(content: string | OpenAIContentBlock[]): string {
+function extractText(content: string | OpenAIContentBlock[] | null): string {
+  if (content === null || content === undefined) {
+    return "";
+  }
   if (typeof content === "string") {
     return content;
   }
@@ -176,6 +183,11 @@ export function messagesToPrompt(
         // Previous assistant responses for context
         parts.push(`<previous_response>\n${text}\n</previous_response>\n`);
         break;
+
+      case "tool":
+        // Client-executed tool results (OpenWebUI sends role="tool")
+        parts.push(`<tool_result>\n${text}\n</tool_result>\n`);
+        break;
     }
   }
 
@@ -183,16 +195,52 @@ export function messagesToPrompt(
 }
 
 /**
+ * Render client tool definitions as a system-level instruction block.
+ * Claude Code has no native mechanism for client-executed tools in --print
+ * mode, so we describe them and require a <tool_call> JSON envelope - the
+ * response adapter parses it back into OpenAI tool_calls.
+ */
+export function toolsToPromptBlock(tools: OpenAIToolDefinition[]): string {
+  const defs = tools
+    .map((t) => {
+      const params = t.function.parameters
+        ? JSON.stringify(t.function.parameters)
+        : "{}";
+      return `- ${t.function.name}: ${t.function.description || "(no description)"}\n  parameters: ${params}`;
+    })
+    .join("\n");
+
+  return [
+    "<available_tools>",
+    "The client provides the following tools. You CANNOT execute them yourself -",
+    "the client runs them and sends the result back as a tool message.",
+    "To request a tool call, respond with ONLY a JSON block in this exact format:",
+    '<tool_call>{"name": "<tool_name>", "arguments": {...}}</tool_call>',
+    "No other text before or after. One tool call per response.",
+    "If no tool is needed, answer normally.",
+    "",
+    defs,
+    "</available_tools>",
+  ].join("\n");
+}
+
+/**
  * Convert OpenAI chat request to CLI input format
  */
 export function openaiToCli(request: OpenAIChatRequest): CliInput {
   const images = extractImages(request.messages);
+  const tools = request.tools;
+  let prompt = messagesToPrompt(request.messages);
+  if (tools && tools.length > 0) {
+    prompt = toolsToPromptBlock(tools) + "\n\n" + prompt;
+  }
   return {
-    prompt: messagesToPrompt(request.messages),
+    prompt,
     model: extractModel(request.model),
     sessionId: request.user, // Use OpenAI's user field for session mapping
     effort: extractEffort(request),
     ...(images.length > 0 ? { images } : {}),
+    ...(tools && tools.length > 0 ? { tools, hasClientTools: true } : {}),
   };
 }
 
@@ -212,13 +260,19 @@ export function openaiToCliDelta(
 
   const source = newMessages.length ? newMessages : request.messages;
   const images = extractImages(source);
+  const tools = request.tools;
+  // Fallback to full history if nothing new was found (shouldn't happen,
+  // but never send an empty prompt to the CLI)
+  let prompt = messagesToPrompt(source);
+  if (tools && tools.length > 0) {
+    prompt = toolsToPromptBlock(tools) + "\n\n" + prompt;
+  }
   return {
-    // Fallback to full history if nothing new was found (shouldn't happen,
-    // but never send an empty prompt to the CLI)
-    prompt: messagesToPrompt(source),
+    prompt,
     model: extractModel(request.model),
     sessionId: request.user,
     effort: extractEffort(request),
     ...(images.length > 0 ? { images } : {}),
+    ...(tools && tools.length > 0 ? { tools, hasClientTools: true } : {}),
   };
 }

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -1,0 +1,298 @@
+/**
+ * Admin endpoints: in-container re-authentication of the Claude CLI.
+ *
+ * Flow (no container/SSH access needed):
+ *   1. POST /admin/relogin/start   → spawns `claude auth login`
+ *      inside the container, parses the OAuth URL from its output and
+ *      returns it. The admin opens the URL in any browser and authorizes.
+ *   2. POST /admin/relogin/complete { code } → pastes the authorization
+ *      code back into the waiting CLI process via stdin.
+ *   3. GET  /admin/relogin/status  → poll the current state.
+ *
+ * The CLI writes fresh credentials to $CLAUDE_CONFIG_DIR (~/.claude),
+ * which lives on the persistent /data volume - so the new tokens survive
+ * container restarts and redeploys.
+ *
+ * All routes are protected by adminAuth (PROXY_ADMIN_KEY, falling back to
+ * PROXY_API_KEY).
+ */
+
+import { Router } from "express";
+import { spawn, execFile, ChildProcess } from "child_process";
+
+type ReloginState = "idle" | "awaiting_code" | "success" | "failed";
+
+interface ReloginSession {
+  state: ReloginState;
+  url: string | null;
+  detail: string | null;
+  startedAt: number;
+  proc: ChildProcess | null;
+  buffer: string;
+}
+
+const SESSION_TIMEOUT_MS = 10 * 60 * 1000; // 10 min to complete the flow
+
+let session: ReloginSession | null = null;
+
+function resetSession(): void {
+  if (session?.proc) {
+    session.proc.kill("SIGTERM");
+  }
+  session = null;
+}
+
+function isExpired(s: ReloginSession): boolean {
+  return Date.now() - s.startedAt > SESSION_TIMEOUT_MS;
+}
+
+/**
+ * Try to extract the OAuth authorize URL from CLI output.
+ * The CLI prints something like "Open this URL: https://claude.ai/oauth/authorize?..."
+ */
+function extractUrl(text: string): string | null {
+  const m = text.match(/https:\/\/[^\s"']*(?:oauth|authorize|login)[^\s"']*/i);
+  return m ? m[0] : null;
+}
+
+export function createAdminRouter(): Router {
+  const router = Router();
+
+  /**
+   * POST /admin/relogin/start
+   * Starts `claude auth login` in the container and returns
+   * the URL the admin must open in a browser.
+   */
+  router.post("/relogin/start", (_req, res) => {
+    if (session && !isExpired(session) && session.state === "awaiting_code") {
+      // A flow is already waiting - return its URL again (idempotent for retries)
+      res.json({ state: session.state, url: session.url, note: "Flow already in progress" });
+      return;
+    }
+    resetSession();
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn("claude", ["auth", "login"], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err) {
+      res.status(500).json({
+        error: { message: `Failed to spawn claude CLI: ${String(err)}`, type: "server_error", code: null },
+      });
+      return;
+    }
+
+    session = {
+      state: "awaiting_code",
+      url: null,
+      detail: null,
+      startedAt: Date.now(),
+      proc,
+      buffer: "",
+    };
+
+    const onData = (chunk: Buffer) => {
+      if (!session) return;
+      session.buffer += chunk.toString();
+      if (!session.url) {
+        session.url = extractUrl(session.buffer);
+        if (session.url) {
+          console.log("[Admin] Relogin URL ready");
+        }
+      }
+    };
+    proc.stdout?.on("data", onData);
+    proc.stderr?.on("data", onData);
+
+    proc.on("close", (code) => {
+      if (!session) return;
+      if (session.state === "success") return; // already completed via /complete
+      session.state = code === 0 ? "success" : "failed";
+      session.detail = `claude auth login exited with code ${code}`;
+      session.proc = null;
+      console.log(`[Admin] Relogin process closed: ${session.state}`);
+    });
+
+    // Give the CLI a moment to print the URL before responding
+    const deadline = Date.now() + 8000;
+    const poll = setInterval(() => {
+      if (!session) {
+        clearInterval(poll);
+        return;
+      }
+      if (session.url || Date.now() > deadline) {
+        clearInterval(poll);
+        if (session.url) {
+          res.json({
+            state: session.state,
+            url: session.url,
+            instructions:
+              "Open the URL in a browser, authorize, then POST the returned code to /admin/relogin/complete",
+          });
+        } else {
+          res.status(202).json({
+            state: session.state,
+            url: null,
+            note: "CLI started but has not printed a URL yet - poll GET /admin/relogin/status",
+          });
+        }
+      }
+    }, 250);
+  });
+
+  /**
+   * POST /admin/relogin/complete { code: "..." }
+   * Feeds the authorization code into the waiting CLI process.
+   */
+  router.post("/relogin/complete", (req, res) => {
+    if (!session || session.state !== "awaiting_code" || !session.proc) {
+      res.status(409).json({
+        error: {
+          message: "No login flow in progress. Call POST /admin/relogin/start first.",
+          type: "invalid_request_error",
+          code: "no_flow",
+        },
+      });
+      return;
+    }
+    if (isExpired(session)) {
+      resetSession();
+      res.status(410).json({
+        error: {
+          message: "Login flow timed out (10 min). Start again with POST /admin/relogin/start.",
+          type: "invalid_request_error",
+          code: "flow_expired",
+        },
+      });
+      return;
+    }
+
+    const code = (req.body?.code || "").toString().trim();
+    if (!code) {
+      res.status(400).json({
+        error: { message: "Missing 'code' in request body.", type: "invalid_request_error", code: "missing_code" },
+      });
+      return;
+    }
+
+    const proc = session.proc;
+    const current = session;
+
+    const timeout = setTimeout(() => {
+      if (session === current && current.state === "awaiting_code") {
+        res.status(202).json({ state: current.state, note: "Code submitted, waiting for CLI to finish - poll /admin/relogin/status" });
+      }
+    }, 15000);
+
+    const onClose = (exitCode: number | null) => {
+      clearTimeout(timeout);
+      current.state = exitCode === 0 ? "success" : "failed";
+      current.detail = exitCode === 0
+        ? "Login successful - credentials written to the persistent volume."
+        : `Login failed (exit code ${exitCode}). Output: ${current.buffer.slice(-500)}`;
+      current.proc = null;
+      console.log(`[Admin] Relogin completed: ${current.state}`);
+      if (!res.headersSent) {
+        res.status(exitCode === 0 ? 200 : 502).json({ state: current.state, detail: current.detail });
+      }
+      // Clean up the session after responding - on success the CLI output may
+      // contain account details we don't want to keep in memory
+      if (session === current) {
+        session = null;
+      }
+    };
+
+    proc.once("close", onClose);
+    proc.stdin?.write(code + "\n");
+    proc.stdin?.end();
+  });
+
+  /**
+   * GET /admin/relogin/status
+   */
+  router.get("/relogin/status", (_req, res) => {
+    if (!session) {
+      res.json({ state: "idle" });
+      return;
+    }
+    res.json({
+      state: session.state,
+      url: session.url,
+      detail: session.detail,
+      expiresIn: Math.max(0, SESSION_TIMEOUT_MS - (Date.now() - session.startedAt)),
+    });
+  });
+
+  /**
+   * POST /admin/relogin/cancel
+   */
+  router.post("/relogin/cancel", (_req, res) => {
+    resetSession();
+    res.json({ state: "idle" });
+  });
+
+  /**
+   * GET /admin/usage
+   * Subscription usage as reported by the CLI itself ("claude --print /usage").
+   * Answers directly from the CLI, costs no API tokens. Cached for 60s.
+   */
+  router.get("/usage", (_req, res) => {
+    const now = Date.now();
+    if (usageCache && now - usageCache.at < 60_000) {
+      res.json({ ...usageCache.data, cached: true });
+      return;
+    }
+
+    execFile(
+      "claude",
+      ["--print", "/usage"],
+      { timeout: 20_000, maxBuffer: 64 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          res.status(502).json({
+            error: {
+              message: `Usage query failed: ${stderr?.toString().trim() || err.message}`,
+              type: "server_error",
+              code: null,
+            },
+          });
+          return;
+        }
+        res.json({ ...parseUsage(stdout.toString()), cached: false });
+      }
+    );
+  });
+
+  return router;
+}
+
+let usageCache: { at: number; data: Record<string, unknown> } | null = null;
+
+/**
+ * Parse the plain-text output of "claude --print /usage" into structured data.
+ * Format (CLI 2.1.x), lines like:
+ *   Current session: 3% used · resets Aug 16, 5:50pm (UTC)
+ *   Current week (all models): 7% used · resets Aug 19, 9am (UTC)
+ */
+function parseUsage(text: string): Record<string, unknown> {
+  const result: Record<string, unknown> = { raw: text.trim() };
+  const lineRe =
+    /^(Current session|Current week(?: \(([^)]+)\))?)\s*:\s*(\d+)% used(?:\s*·\s*resets (.+))?$/i;
+
+  for (const line of text.split("\n")) {
+    const m = line.trim().match(lineRe);
+    if (!m) continue;
+    const scope = m[2] ? m[2].toLowerCase().replace(/\s+/g, "_") : null;
+    const key = m[1].toLowerCase().startsWith("current session")
+      ? "session"
+      : scope
+        ? `week_${scope}`
+        : "week_all_models";
+    result[key] = {
+      percent_used: Number(m[3]),
+      ...(m[4] ? { resets: m[4].trim() } : {}),
+    };
+  }
+  return result;
+}

--- a/src/server/admin.ts
+++ b/src/server/admin.ts
@@ -259,7 +259,9 @@ export function createAdminRouter(): Router {
           });
           return;
         }
-        res.json({ ...parseUsage(stdout.toString()), cached: false });
+        const data = parseUsage(stdout.toString());
+        usageCache = { at: Date.now(), data };
+        res.json({ ...data, cached: false });
       }
     );
   });

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,0 +1,160 @@
+/**
+ * API Key Authentication Middleware
+ *
+ * Protects the proxy endpoints with a Bearer token (OpenAI style).
+ * Configure via PROXY_API_KEY environment variable.
+ *
+ * Behavior:
+ * - If PROXY_API_KEY is not set, a secure random key is generated at
+ *   startup and printed to the logs (auth stays ON).
+ * - Set PROXY_API_KEY=off to explicitly disable authentication
+ *   (only recommended for local development).
+ * - /health is always public so uptime checks keep working.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import { randomBytes, timingSafeEqual } from "crypto";
+
+let configuredKey: string | null = null;
+let authEnabled = false;
+
+/**
+ * Initialize the API key from the environment.
+ * Returns a status object so the caller can log what happened.
+ */
+export function initApiKey(): {
+  enabled: boolean;
+  generated: boolean;
+  key: string | null;
+} {
+  const raw = process.env.PROXY_API_KEY?.trim();
+
+  if (raw && raw.toLowerCase() === "off") {
+    configuredKey = null;
+    authEnabled = false;
+    return { enabled: false, generated: false, key: null };
+  }
+
+  if (raw) {
+    configuredKey = raw;
+    authEnabled = true;
+    return { enabled: true, generated: false, key: raw };
+  }
+
+  // No key configured: generate one instead of running unprotected
+  const generated = `sk-proxy-${randomBytes(24).toString("hex")}`;
+  configuredKey = generated;
+  authEnabled = true;
+  return { enabled: true, generated: true, key: generated };
+}
+
+export function isAuthEnabled(): boolean {
+  return authEnabled;
+}
+
+let configuredAdminKey: string | null = null;
+
+/**
+ * Initialize the optional admin key (PROXY_ADMIN_KEY).
+ * Falls back to the regular API key when no dedicated admin key is set.
+ * Returns the same shape as initApiKey for startup logging.
+ */
+export function initAdminKey(): { configured: boolean; fallback: boolean } {
+  const raw = process.env.PROXY_ADMIN_KEY?.trim();
+  if (raw) {
+    configuredAdminKey = raw;
+    return { configured: true, fallback: false };
+  }
+  return { configured: false, fallback: true };
+}
+
+/**
+ * Express middleware for /admin/* routes.
+ * Requires PROXY_ADMIN_KEY; if unset, the regular PROXY_API_KEY is accepted.
+ * If neither exists, admin routes are locked (403).
+ */
+export function adminAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const effective = configuredAdminKey || configuredKey;
+
+  if (!effective) {
+    res.status(403).json({
+      error: {
+        message:
+          "Admin endpoints are locked. Set PROXY_ADMIN_KEY (or PROXY_API_KEY) to enable them.",
+        type: "invalid_request_error",
+        code: "admin_locked",
+      },
+    });
+    return;
+  }
+
+  const header = req.headers.authorization;
+  const token = header?.startsWith("Bearer ") ? header.slice(7).trim() : null;
+
+  if (!token || !safeEqual(token, effective)) {
+    res.status(401).json({
+      error: {
+        message: "Invalid admin key.",
+        type: "invalid_request_error",
+        code: "invalid_admin_key",
+      },
+    });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Constant-time string comparison to avoid timing attacks.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Express middleware enforcing the API key on all routes except /health.
+ */
+export function apiKeyAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!authEnabled || !configuredKey) {
+    next();
+    return;
+  }
+
+  // Health check stays public (uptime monitors, EasyPanel checks)
+  // Admin routes handle their own (stricter) auth via adminAuth
+  if (req.path === "/health" || req.path.startsWith("/admin")) {
+    next();
+    return;
+  }
+
+  const header = req.headers.authorization;
+  const token = header?.startsWith("Bearer ") ? header.slice(7).trim() : null;
+
+  if (!token || !safeEqual(token, configuredKey)) {
+    res.status(401).json({
+      error: {
+        message:
+          "Invalid or missing API key. Provide it as 'Authorization: Bearer <key>'.",
+        type: "invalid_request_error",
+        code: "invalid_api_key",
+      },
+    });
+    return;
+  }
+
+  next();
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,8 @@
 import express, { Express, Request, Response, NextFunction } from "express";
 import { createServer, Server } from "http";
 import { handleChatCompletions, handleModels, handleHealth } from "./routes.js";
+import { apiKeyAuth, adminAuth } from "./auth.js";
+import { createAdminRouter } from "./admin.js";
 
 export interface ServerConfig {
   port: number;
@@ -69,6 +71,12 @@ function createApp(): Express {
   app.options("*", (_req: Request, res: Response) => {
     res.sendStatus(200);
   });
+
+  // API key authentication (protects all routes except /health, see auth.ts)
+  app.use(apiKeyAuth);
+
+  // Admin routes (relogin flow) - separate key requirement
+  app.use("/admin", adminAuth, createAdminRouter());
 
   // Routes
   app.get("/health", handleHealth);

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -6,7 +6,8 @@
 
 import type { Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
-import { ClaudeSubprocess } from "../subprocess/manager.js";
+import { existsSync, readdirSync } from "fs";
+import { ClaudeSubprocess, stageImages, cleanupImages } from "../subprocess/manager.js";
 import { openaiToCli, openaiToCliDelta } from "../adapter/openai-to-cli.js";
 import {
   cliResultToOpenai,
@@ -15,6 +16,21 @@ import {
 import { getSession, setSession, clearSession } from "../subprocess/session-store.js";
 import type { OpenAIChatRequest, OpenAIToolCall } from "../types/openai.js";
 import type { ClaudeCliAssistant, ClaudeCliResult, ClaudeCliStreamEvent } from "../types/claude-cli.js";
+
+/**
+ * Check whether Claude CLI credentials exist at all. On a fresh container
+ * with an empty /data volume, every request would otherwise run into the
+ * CLI's onboarding/login failure - we can answer that upfront instead.
+ */
+function hasClaudeCredentials(): boolean {
+  const dir = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  try {
+    if (!existsSync(dir)) return false;
+    return readdirSync(dir).some((f) => f.endsWith(".json"));
+  } catch {
+    return false;
+  }
+}
 
 /**
  * User-facing guidance when the Claude CLI's OAuth session has expired.
@@ -77,6 +93,8 @@ function resolveCliInput(body: OpenAIChatRequest): {
   if (existing) {
     const cliInput = openaiToCliDelta(body, existing.messageCount);
     cliInput.sessionId = existing.claudeSessionId;
+    // Effort is per-request, not per-session: honor it on resumed turns too
+    cliInput.effort = openaiToCli(body).effort;
     return { cliInput, sessionKey, resume: true };
   }
 
@@ -113,15 +131,64 @@ export async function handleChatCompletions(
       return;
     }
 
+    // Fresh container without any login: answer upfront instead of
+    // letting the request run into the CLI's onboarding failure
+    if (!hasClaudeCredentials()) {
+      console.error("[Auth] No Claude credentials found - prompting admin to run the relogin flow");
+      const guidance = authExpiredResponse(requestId, "claude-sonnet-4");
+      if (stream) {
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+        res.flushHeaders();
+        const chunk = {
+          id: guidance.id,
+          object: "chat.completion.chunk",
+          created: guidance.created,
+          model: guidance.model,
+          choices: [
+            { index: 0, delta: { role: "assistant", content: guidance.choices[0].message.content }, finish_reason: null },
+            { index: 0, delta: {}, finish_reason: "stop" },
+          ],
+        };
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        res.write("data: [DONE]\n\n");
+        res.end();
+      } else {
+        res.json(guidance);
+      }
+      return;
+    }
+
     // Convert to CLI input format, resuming a persisted session when we have one
     const { cliInput, sessionKey, resume } = resolveCliInput(body);
     const subprocess = new ClaudeSubprocess();
     const sessionCtx: SessionContext = { sessionKey, resume, messageCount: body.messages.length };
 
-    if (stream) {
-      await handleStreamingResponse(req, res, subprocess, cliInput, requestId, sessionCtx);
-    } else {
-      await handleNonStreamingResponse(res, subprocess, cliInput, requestId, sessionCtx);
+    // Stage attached images (OpenAI image_url blocks) as temp files and point
+    // the prompt at them - Claude Code reads them via its Read tool
+    let stagedImages: string[] = [];
+    if (cliInput.images && cliInput.images.length > 0) {
+      stagedImages = await stageImages(cliInput.images);
+      delete cliInput.images; // don't hold base64 in memory longer than needed
+      if (stagedImages.length > 0) {
+        const listing = stagedImages.map((p, i) => `${i + 1}. ${p}`).join("\n");
+        cliInput.prompt =
+          `[Attached images - use your Read tool on each file to view them]\n${listing}\n\n` +
+          cliInput.prompt;
+      }
+    }
+
+    try {
+      if (stream) {
+        await handleStreamingResponse(req, res, subprocess, cliInput, requestId, sessionCtx);
+      } else {
+        await handleNonStreamingResponse(res, subprocess, cliInput, requestId, sessionCtx);
+      }
+    } finally {
+      if (stagedImages.length > 0) {
+        await cleanupImages(stagedImages);
+      }
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -334,6 +401,13 @@ async function handleStreamingResponse(
             completion_tokens: result.usage.output_tokens || 0,
             total_tokens:
               (result.usage.input_tokens || 0) + (result.usage.output_tokens || 0),
+            // Prompt caching is automatic in Claude Code - surface the metrics
+            ...(result.usage.cache_read_input_tokens
+              ? { cache_read_input_tokens: result.usage.cache_read_input_tokens }
+              : {}),
+            ...(result.usage.cache_creation_input_tokens
+              ? { cache_creation_input_tokens: result.usage.cache_creation_input_tokens }
+              : {}),
           };
         }
         res.write(`data: ${JSON.stringify(doneChunk)}\n\n`);
@@ -403,6 +477,7 @@ async function handleStreamingResponse(
       model: cliInput.model,
       sessionId: cliInput.sessionId,
       resume: sessionCtx.resume,
+      effort: cliInput.effort,
     }).catch((err) => {
       console.error("[Streaming] Subprocess start error:", err);
       reject(err);
@@ -499,6 +574,7 @@ async function handleNonStreamingResponse(
         model: cliInput.model,
         sessionId: cliInput.sessionId,
         resume: sessionCtx.resume,
+        effort: cliInput.effort,
       })
       .catch((error) => {
         res.status(500).json({

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -49,6 +49,34 @@ const AUTH_EXPIRED_MESSAGE = [
   "Details: siehe DOCKER.md, Abschnitt 'Re-Login ohne Container-Zugriff'.",
 ].join("\n");
 
+/**
+ * Parse a <tool_call>{...}</tool_call> envelope from Claude's text output.
+ * Claude Code has no client-executed tool protocol in --print mode, so tool
+ * requests arrive as text; we convert them into OpenAI tool_calls.
+ */
+function parseToolCall(text: string): { name: string; arguments: string } | null {
+  const m = text.match(/<tool_call>\s*(\{[\s\S]*?\})\s*<\/tool_call>/);
+  if (!m) return null;
+  try {
+    const parsed = JSON.parse(m[1]);
+    if (typeof parsed.name !== "string") return null;
+    return {
+      name: parsed.name,
+      arguments:
+        typeof parsed.arguments === "string"
+          ? parsed.arguments
+          : JSON.stringify(parsed.arguments ?? {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+let toolCallSeq = 0;
+function nextToolCallId(): string {
+  return `call_${Date.now().toString(36)}${(toolCallSeq++).toString(36)}`;
+}
+
 /** Build an OpenAI-style assistant message body (non-streaming) */
 function authExpiredResponse(requestId: string, model: string) {
   return {
@@ -249,6 +277,10 @@ async function handleStreamingResponse(
     let hasEmittedText = false;
     let toolCallIndex = 0;
     let inToolBlock = false;
+    let accumulatedText = "";
+    // When the client provides tools, Claude asks for them via a <tool_call>
+    // text envelope - buffer text so we can convert it into real tool_calls
+    const expectsClientTools = !!cliInput.hasClientTools;
 
     // Handle actual client disconnect (response stream closed)
     res.on("close", () => {
@@ -280,15 +312,44 @@ async function handleStreamingResponse(
       }
     });
 
+    // Extended thinking: forward as OpenAI-style reasoning chunks
+    // (OpenWebUI renders delta.reasoning as a collapsible "thinking" section).
+    // Note: subscription-billed thinking is often redacted/encrypted server-side
+    // (empty deltas with only estimated_tokens) - those are skipped here.
+    subprocess.on("thinking_delta", (event: ClaudeCliStreamEvent) => {
+      const delta = event.event.delta;
+      const text = (delta?.type === "thinking_delta" && delta.thinking) || "";
+      if (text && !res.writableEnded) {
+        const chunk = {
+          id: `chatcmpl-${requestId}`,
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: lastModel,
+          choices: [{
+            index: 0,
+            delta: { reasoning: text },
+            finish_reason: null,
+          }],
+        };
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      }
+    });
+
     // Handle streaming content deltas
     subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
       const delta = event.event.delta;
       let text = (delta?.type === "text_delta" && delta.text) || "";
+      if (expectsClientTools) {
+        // Buffer instead of streaming: the text may be a <tool_call> envelope
+        // that must be converted into tool_calls, never shown to the user
+        accumulatedText += text;
+        return;
+      }
       // CLI surfaces auth failures as plain text on stdout in some failure
-      // modes - replace with actionable guidance
+      // modes - swallow them here; the error/close handlers emit the guidance
+      // message exactly once.
       if (text && subprocess.hasAuthError()) {
-        text = AUTH_EXPIRED_MESSAGE;
-        isComplete = true;
+        return;
       }
       if (text && !res.writableEnded) {
         const chunk = {
@@ -392,6 +453,55 @@ async function handleStreamingResponse(
       if (sessionCtx.sessionKey && cliInput.sessionId) {
         setSession(sessionCtx.sessionKey, cliInput.sessionId, sessionCtx.messageCount);
       }
+      // Client-tool request? The streamed text is a <tool_call> envelope -
+      // replace it with proper OpenAI tool_calls chunks
+      if (expectsClientTools) {
+        const tc = parseToolCall(accumulatedText || result.result || "");
+        if (tc && !res.writableEnded) {
+          const callId = nextToolCallId();
+          const chunk = {
+            id: `chatcmpl-${requestId}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: lastModel,
+            choices: [{
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [{
+                  index: 0,
+                  id: callId,
+                  type: "function",
+                  function: { name: tc.name, arguments: tc.arguments },
+                }],
+              },
+              finish_reason: "tool_calls",
+            }],
+          };
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          res.write("data: [DONE]\n\n");
+          res.end();
+          resolve();
+          return;
+        }
+      }
+      // No tool call detected - flush the buffered text as regular content
+      if (expectsClientTools && accumulatedText && !res.writableEnded) {
+        const textChunk = {
+          id: `chatcmpl-${requestId}`,
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: lastModel,
+          choices: [{
+            index: 0,
+            delta: { role: "assistant", content: accumulatedText },
+            finish_reason: null,
+          }],
+        };
+        res.write(`data: ${JSON.stringify(textChunk)}\n\n`);
+        hasEmittedText = true;
+        isFirst = false;
+      }
       if (!res.writableEnded) {
         // Send final done chunk with finish_reason and usage data
         const doneChunk = createDoneChunk(requestId, lastModel);
@@ -478,6 +588,7 @@ async function handleStreamingResponse(
       sessionId: cliInput.sessionId,
       resume: sessionCtx.resume,
       effort: cliInput.effort,
+      disableBuiltinTools: cliInput.hasClientTools,
     }).catch((err) => {
       console.error("[Streaming] Subprocess start error:", err);
       reject(err);
@@ -545,6 +656,40 @@ async function handleNonStreamingResponse(
         if (sessionCtx.sessionKey && cliInput.sessionId) {
           setSession(sessionCtx.sessionKey, cliInput.sessionId, sessionCtx.messageCount);
         }
+        // Client-tool request? Convert <tool_call> text into OpenAI tool_calls
+        if (cliInput.hasClientTools) {
+          const tc = parseToolCall(finalResult.result || "");
+          if (tc) {
+            res.json({
+              id: `chatcmpl-${requestId}`,
+              object: "chat.completion",
+              created: Math.floor(Date.now() / 1000),
+              model: "claude-sonnet-4",
+              choices: [{
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: null,
+                  tool_calls: [{
+                    id: nextToolCallId(),
+                    type: "function",
+                    function: { name: tc.name, arguments: tc.arguments },
+                  }],
+                },
+                finish_reason: "tool_calls",
+              }],
+              usage: {
+                prompt_tokens: finalResult.usage?.input_tokens || 0,
+                completion_tokens: finalResult.usage?.output_tokens || 0,
+                total_tokens:
+                  (finalResult.usage?.input_tokens || 0) +
+                  (finalResult.usage?.output_tokens || 0),
+              },
+            });
+            resolve();
+            return;
+          }
+        }
         res.json(cliResultToOpenai(finalResult, requestId));
       } else {
         if (sessionCtx.resume && sessionCtx.sessionKey) {
@@ -575,6 +720,7 @@ async function handleNonStreamingResponse(
         sessionId: cliInput.sessionId,
         resume: sessionCtx.resume,
         effort: cliInput.effort,
+        disableBuiltinTools: cliInput.hasClientTools,
       })
       .catch((error) => {
         res.status(500).json({

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -16,6 +16,41 @@ import { getSession, setSession, clearSession } from "../subprocess/session-stor
 import type { OpenAIChatRequest, OpenAIToolCall } from "../types/openai.js";
 import type { ClaudeCliAssistant, ClaudeCliResult, ClaudeCliStreamEvent } from "../types/claude-cli.js";
 
+/**
+ * User-facing guidance when the Claude CLI's OAuth session has expired.
+ * Returned as a normal assistant message instead of a raw 500 so the user
+ * sees actionable steps directly in their chat client.
+ */
+const AUTH_EXPIRED_MESSAGE = [
+  "Die Claude-Anmeldung auf dem Server ist abgelaufen – Anfragen sind derzeit nicht moeglich.",
+  "",
+  "Neuanmeldung direkt ueber die Admin-API (kein Server-Zugriff noetig):",
+  "1. `POST /admin/relogin/start` (mit Admin-Key) – die Antwort enthaelt eine Login-URL.",
+  "2. URL im Browser oeffnen und die Anmeldung bestaetigen.",
+  "3. Den angezeigten Code per `POST /admin/relogin/complete` zurueckschicken.",
+  "4. Danach funktioniert dieser Chat sofort wieder – die neuen Tokens liegen persistent im Volume.",
+  "",
+  "Details: siehe DOCKER.md, Abschnitt 'Re-Login ohne Container-Zugriff'.",
+].join("\n");
+
+/** Build an OpenAI-style assistant message body (non-streaming) */
+function authExpiredResponse(requestId: string, model: string) {
+  return {
+    id: `chatcmpl-${requestId}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: AUTH_EXPIRED_MESSAGE },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
+
 interface SessionContext {
   sessionKey: string | undefined;
   resume: boolean;
@@ -181,7 +216,13 @@ async function handleStreamingResponse(
     // Handle streaming content deltas
     subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
       const delta = event.event.delta;
-      const text = (delta?.type === "text_delta" && delta.text) || "";
+      let text = (delta?.type === "text_delta" && delta.text) || "";
+      // CLI surfaces auth failures as plain text on stdout in some failure
+      // modes - replace with actionable guidance
+      if (text && subprocess.hasAuthError()) {
+        text = AUTH_EXPIRED_MESSAGE;
+        isComplete = true;
+      }
       if (text && !res.writableEnded) {
         const chunk = {
           id: `chatcmpl-${requestId}`,
@@ -309,6 +350,23 @@ async function handleStreamingResponse(
       if (sessionCtx.resume && sessionCtx.sessionKey) {
         clearSession(sessionCtx.sessionKey);
       }
+      if (subprocess.hasAuthError()) {
+        console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+        if (!res.writableEnded) {
+          const chunk = {
+            id: `chatcmpl-${requestId}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: lastModel,
+            choices: [{ index: 0, delta: { role: "assistant", content: AUTH_EXPIRED_MESSAGE }, finish_reason: null }],
+          };
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          res.write("data: [DONE]\n\n");
+          res.end();
+        }
+        resolve();
+        return;
+      }
       if (!res.writableEnded) {
         res.write(
           `data: ${JSON.stringify({
@@ -391,6 +449,12 @@ async function handleNonStreamingResponse(
       if (sessionCtx.resume && sessionCtx.sessionKey) {
         clearSession(sessionCtx.sessionKey);
       }
+      if (subprocess.hasAuthError()) {
+        console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+        res.json(authExpiredResponse(requestId, "claude-sonnet-4"));
+        resolve();
+        return;
+      }
       res.status(500).json({
         error: {
           message: error.message,
@@ -412,13 +476,18 @@ async function handleNonStreamingResponse(
           clearSession(sessionCtx.sessionKey);
         }
         if (!res.headersSent) {
-          res.status(500).json({
-            error: {
-              message: `Claude CLI exited with code ${code} without response`,
-              type: "server_error",
-              code: null,
-            },
-          });
+          if (subprocess.hasAuthError()) {
+            console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+            res.json(authExpiredResponse(requestId, "claude-sonnet-4"));
+          } else {
+            res.status(500).json({
+              error: {
+                message: `Claude CLI exited with code ${code} without response`,
+                type: "server_error",
+                code: null,
+              },
+            });
+          }
         }
       }
       resolve();

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -8,8 +8,41 @@
  *   node dist/server/standalone.js [port]
  */
 
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { startServer, stopServer } from "./index.js";
-import { verifyClaude, verifyAuth } from "../subprocess/manager.js";
+import { verifyClaude } from "../subprocess/manager.js";
+import { initApiKey, initAdminKey } from "./auth.js";
+
+/**
+ * Minimal .env loader: only sets variables that are not already present in
+ * process.env, so container/CI environment variables always win.
+ * No external dependency needed.
+ */
+function loadEnvFile(): void {
+  let content: string;
+  try {
+    content = readFileSync(".env", "utf8");
+  } catch {
+    return; // no .env file - fine
+  }
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
 
 const DEFAULT_PORT = 3456;
 
@@ -17,11 +50,40 @@ async function main(): Promise<void> {
   console.log("Claude Code CLI Provider - Standalone Server");
   console.log("============================================\n");
 
-  // Parse port from command line
-  const port = parseInt(process.argv[2] || String(DEFAULT_PORT), 10);
+  loadEnvFile();
+
+  // Parse port: CLI argument > PORT env var > default
+  const port = parseInt(
+    process.argv[2] || process.env.PORT || String(DEFAULT_PORT),
+    10
+  );
   if (isNaN(port) || port < 1 || port > 65535) {
-    console.error(`Invalid port: ${process.argv[2]}`);
+    console.error(`Invalid port: ${process.argv[2] || process.env.PORT}`);
     process.exit(1);
+  }
+
+  // Host binding: 0.0.0.0 is required inside Docker containers,
+  // 127.0.0.1 is the safer default for local development.
+  const host = process.env.HOST || "127.0.0.1";
+
+  // API key authentication
+  const keyStatus = initApiKey();
+  if (keyStatus.enabled && keyStatus.generated) {
+    console.log("[Auth] No PROXY_API_KEY configured - generated a random one:");
+    console.log(`[Auth]   ${keyStatus.key}`);
+    console.log("[Auth] Set PROXY_API_KEY in your environment to use your own.\n");
+  } else if (keyStatus.enabled) {
+    console.log("[Auth] API key authentication: ENABLED\n");
+  } else {
+    console.log("[Auth] WARNING: API key authentication DISABLED (PROXY_API_KEY=off)");
+    console.log("[Auth] Only do this for local development!\n");
+  }
+
+  const adminStatus = initAdminKey();
+  if (adminStatus.configured) {
+    console.log("[Auth] Admin endpoints (/admin/*): ENABLED (dedicated PROXY_ADMIN_KEY)");
+  } else if (keyStatus.enabled) {
+    console.log("[Auth] Admin endpoints (/admin/*): ENABLED (falls back to PROXY_API_KEY)");
   }
 
   // Verify Claude CLI
@@ -33,19 +95,30 @@ async function main(): Promise<void> {
   }
   console.log(`  Claude CLI: ${cliCheck.version || "OK"}`);
 
-  // Verify authentication
+  // Check for credentials. The CLI can also store them in the OS keychain,
+  // which we can't inspect - so a missing config dir is a warning, not fatal.
   console.log("Checking authentication...");
-  const authCheck = await verifyAuth();
-  if (!authCheck.ok) {
-    console.error(`Error: ${authCheck.error}`);
-    console.error("Please run: claude auth login");
-    process.exit(1);
+  const configDir = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  let hasCredentials = false;
+  try {
+    hasCredentials =
+      existsSync(configDir) && readdirSync(configDir).some((f) => f.endsWith(".json"));
+  } catch {
+    hasCredentials = false;
   }
-  console.log("  Authentication: OK\n");
+  if (hasCredentials) {
+    console.log("  Credentials: found\n");
+  } else {
+    console.log("  Credentials: NOT FOUND");
+    console.log("  The server will start anyway, but chat requests will return a");
+    console.log("  guidance message until you log in via the admin API:");
+    console.log("    POST /admin/relogin/start  ->  open URL in browser");
+    console.log("    POST /admin/relogin/complete  ->  submit the code\n");
+  }
 
   // Start server
   try {
-    await startServer({ port });
+    await startServer({ port, host });
     console.log("\nServer ready. Test with:");
     console.log(`  curl -X POST http://localhost:${port}/v1/chat/completions \\`);
     console.log(`    -H "Content-Type: application/json" \\`);

--- a/src/server/standalone.ts
+++ b/src/server/standalone.ts
@@ -98,11 +98,14 @@ async function main(): Promise<void> {
   // Check for credentials. The CLI can also store them in the OS keychain,
   // which we can't inspect - so a missing config dir is a warning, not fatal.
   console.log("Checking authentication...");
-  const configDir = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  const home = process.env.HOME || "";
+  const configDir = process.env.CLAUDE_CONFIG_DIR || (home ? `${home}/.claude` : "");
   let hasCredentials = false;
   try {
     hasCredentials =
-      existsSync(configDir) && readdirSync(configDir).some((f) => f.endsWith(".json"));
+      configDir !== "" &&
+      existsSync(configDir) &&
+      readdirSync(configDir).some((f) => f.endsWith(".json"));
   } catch {
     hasCredentials = false;
   }

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -25,7 +25,41 @@ import {
   isInputJsonDelta,
   isContentBlockStop,
 } from "../types/claude-cli.js";
-import type { ClaudeModel } from "../adapter/openai-to-cli.js";
+import type { ClaudeModel, CliImage, ClaudeEffort } from "../adapter/openai-to-cli.js";
+import os from "os";
+
+export interface SubprocessOptions {
+  model: ClaudeModel;
+  sessionId?: string;
+  /** Resume an existing persisted session (sessionId) instead of creating a new one */
+  resume?: boolean;
+  cwd?: string;
+  timeout?: number;
+  /** Reasoning effort passed through to the CLI via --effort */
+  effort?: ClaudeEffort;
+  /** Images to stage as temp files so Claude can Read them */
+  images?: CliImage[];
+}
+
+/** Max size per image (decoded), 20 MB - generous but bounded */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
+
+export interface SubprocessEvents {
+  message: (msg: ClaudeCliMessage) => void;
+  assistant: (msg: ClaudeCliAssistant) => void;
+  result: (result: ClaudeCliResult) => void;
+  error: (error: Error) => void;
+  close: (code: number | null) => void;
+  raw: (line: string) => void;
+}
 
 const DEFAULT_TIMEOUT = 900000; // 15 minutes
 
@@ -51,15 +85,56 @@ export function isAuthError(stderr: string, exitCode: number | null): boolean {
   );
 }
 
-export interface SubprocessOptions {
-  model: ClaudeModel;
-  sessionId?: string;
-  /** Resume an existing persisted session (sessionId) instead of creating a new one */
-  resume?: boolean;
-  cwd?: string;
-  timeout?: number;
+/**
+ * Stage request images as temp files so the CLI can read them via the Read tool.
+ * Returns absolute file paths. Caller is responsible for cleanup.
+ * Remote URLs are downloaded (5s timeout, bounded size).
+ */
+export async function stageImages(images: CliImage[]): Promise<string[]> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cmap-img-"));
+  const paths: string[] = [];
+
+  for (let i = 0; i < images.length; i++) {
+    const img = images[i];
+    try {
+      let buffer: Buffer;
+      let mime = img.mimeType;
+
+      if (img.sourceUrl) {
+        const res = await fetch(img.sourceUrl, {
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) continue;
+        const contentLength = Number(res.headers.get("content-length") || 0);
+        if (contentLength > MAX_IMAGE_BYTES) continue;
+        mime = mime || res.headers.get("content-type") || "";
+        buffer = Buffer.from(await res.arrayBuffer());
+      } else {
+        buffer = Buffer.from(img.data, "base64");
+      }
+
+      if (buffer.length === 0 || buffer.length > MAX_IMAGE_BYTES) continue;
+      const ext = MIME_TO_EXT[mime] || ".png";
+      const file = path.join(dir, `image-${i + 1}${ext}`);
+      await fs.writeFile(file, buffer);
+      paths.push(file);
+    } catch {
+      // Skip broken images silently - prompt text still goes through
+    }
+  }
+
+  return paths;
 }
 
+/** Best-effort cleanup of staged image files (whole temp dir) */
+export async function cleanupImages(paths: string[]): Promise<void> {
+  const dirs = new Set(paths.map((p) => path.dirname(p)));
+  for (const dir of dirs) {
+    if (dir.includes("cmap-img-")) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}
 
 /**
  * System prompt appended to Claude CLI to map OpenClaw tool names to Claude Code equivalents.
@@ -325,6 +400,10 @@ export class ClaudeSubprocess extends EventEmitter {
       OPENCLAW_TOOL_MAPPING_PROMPT,
       // Prompt is passed via stdin (avoids E2BIG on large inputs)
     ];
+
+    if (options.effort) {
+      args.push("--effort", options.effort);
+    }
 
     if (options.sessionId && options.resume) {
       // Continue a previously persisted session — avoids replaying full history

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -27,6 +27,30 @@ import {
 } from "../types/claude-cli.js";
 import type { ClaudeModel } from "../adapter/openai-to-cli.js";
 
+const DEFAULT_TIMEOUT = 900000; // 15 minutes
+
+/**
+ * Detect authentication/authorization failures from CLI stderr or exit codes.
+ * The CLI surfaces expired OAuth tokens as 401/authentication_error text on
+ * stderr (there is no structured error type in stream-json), so we match the
+ * known signatures.
+ */
+export function isAuthError(stderr: string, exitCode: number | null): boolean {
+  if (exitCode === 401) return true;
+  const text = stderr.toLowerCase();
+  return (
+    text.includes("authentication_error") ||
+    text.includes("authentication failed") ||
+    (text.includes("401") && text.includes("unauthorized")) ||
+    text.includes("oauth token has expired") ||
+    text.includes("token expired") ||
+    text.includes("invalid oauth token") ||
+    (text.includes("not logged in") && text.includes("claude")) ||
+    text.includes("please run /login") ||
+    text.includes("please run claude auth login")
+  );
+}
+
 export interface SubprocessOptions {
   model: ClaudeModel;
   sessionId?: string;
@@ -36,16 +60,6 @@ export interface SubprocessOptions {
   timeout?: number;
 }
 
-export interface SubprocessEvents {
-  message: (msg: ClaudeCliMessage) => void;
-  assistant: (msg: ClaudeCliAssistant) => void;
-  result: (result: ClaudeCliResult) => void;
-  error: (error: Error) => void;
-  close: (code: number | null) => void;
-  raw: (line: string) => void;
-}
-
-const DEFAULT_TIMEOUT = 900000; // 15 minutes
 
 /**
  * System prompt appended to Claude CLI to map OpenClaw tool names to Claude Code equivalents.
@@ -194,6 +208,8 @@ function killProcessTree(
 export class ClaudeSubprocess extends EventEmitter {
   private process: ChildProcess | null = null;
   private buffer: string = "";
+  private stderrBuffer: string = "";
+  private exitCode: number | null = null;
   private timeoutId: NodeJS.Timeout | null = null;
   private isKilled: boolean = false;
 
@@ -255,10 +271,12 @@ export class ClaudeSubprocess extends EventEmitter {
           this.processBuffer();
         });
 
-        // Capture stderr for debugging
+        // Capture stderr for debugging and auth-error detection
         this.process.stderr?.on("data", (chunk: Buffer) => {
           const errorText = chunk.toString().trim();
           if (errorText) {
+            // Keep a bounded tail (4 KB) - enough for error signatures
+            this.stderrBuffer = (this.stderrBuffer + errorText + "\n").slice(-4096);
             // Don't emit as error unless it's actually an error
             // Claude CLI may write debug info to stderr
             if (process.env.DEBUG_SUBPROCESS) {
@@ -269,6 +287,7 @@ export class ClaudeSubprocess extends EventEmitter {
 
         // Handle process close
         this.process.on("close", (code) => {
+          this.exitCode = code;
           if (process.env.DEBUG_SUBPROCESS) {
             console.error(`[Subprocess] Process closed with code: ${code}`);
           }
@@ -388,6 +407,14 @@ export class ClaudeSubprocess extends EventEmitter {
       this.clearTimeout();
       this.isKilled = killProcessTree(this.process, signal);
     }
+  }
+
+  /**
+   * True if the subprocess failed due to an authentication problem
+   * (expired OAuth token, logged out). Check after "close"/"error".
+   */
+  hasAuthError(): boolean {
+    return isAuthError(this.stderrBuffer, this.exitCode);
   }
 
   /**

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -24,6 +24,7 @@ import {
   isToolUseBlockStart,
   isInputJsonDelta,
   isContentBlockStop,
+  isThinkingDelta,
 } from "../types/claude-cli.js";
 import type { ClaudeModel, CliImage, ClaudeEffort } from "../adapter/openai-to-cli.js";
 import os from "os";
@@ -37,6 +38,8 @@ export interface SubprocessOptions {
   timeout?: number;
   /** Reasoning effort passed through to the CLI via --effort */
   effort?: ClaudeEffort;
+  /** Disable all built-in CLI tools (when the client provides its own tool list) */
+  disableBuiltinTools?: boolean;
   /** Images to stage as temp files so Claude can Read them */
   images?: CliImage[];
 }
@@ -104,11 +107,25 @@ export async function stageImages(images: CliImage[]): Promise<string[]> {
         const res = await fetch(img.sourceUrl, {
           signal: AbortSignal.timeout(5000),
         });
-        if (!res.ok) continue;
+        if (!res.ok || !res.body) continue;
         const contentLength = Number(res.headers.get("content-length") || 0);
         if (contentLength > MAX_IMAGE_BYTES) continue;
         mime = mime || res.headers.get("content-type") || "";
-        buffer = Buffer.from(await res.arrayBuffer());
+        // Enforce the size limit while streaming: abort as soon as the body
+        // exceeds MAX_IMAGE_BYTES instead of buffering unbounded data first
+        const chunks: Buffer[] = [];
+        let received = 0;
+        let tooLarge = false;
+        for await (const chunk of res.body) {
+          received += (chunk as Buffer).length;
+          if (received > MAX_IMAGE_BYTES) {
+            tooLarge = true;
+            break;
+          }
+          chunks.push(Buffer.from(chunk));
+        }
+        if (tooLarge) continue;
+        buffer = Buffer.concat(chunks);
       } else {
         buffer = Buffer.from(img.data, "base64");
       }
@@ -405,6 +422,12 @@ export class ClaudeSubprocess extends EventEmitter {
       args.push("--effort", options.effort);
     }
 
+    // Client-provided tools (OpenAI function calling): the CLI must NOT execute
+    // anything itself - no Bash, no Read, nothing. Execution happens client-side.
+    if (options.disableBuiltinTools) {
+      args.push("--tools", "");
+    }
+
     if (options.sessionId && options.resume) {
       // Continue a previously persisted session — avoids replaying full history
       args.push("--resume", options.sessionId);
@@ -456,6 +479,9 @@ export class ClaudeSubprocess extends EventEmitter {
         if (isContentDelta(message)) {
           // Emit content delta for streaming (text_delta only)
           this.emit("content_delta", message as ClaudeCliStreamEvent);
+        } else if (isThinkingDelta(message)) {
+          // Extended thinking stream (visible when effort > default)
+          this.emit("thinking_delta", message as unknown as ClaudeCliStreamEvent);
         } else if (isAssistantMessage(message)) {
           this.emit("assistant", message);
         } else if (isResultMessage(message)) {

--- a/src/types/claude-cli.ts
+++ b/src/types/claude-cli.ts
@@ -110,6 +110,9 @@ export interface ClaudeCliStreamEvent {
     } | {
       type: "input_json_delta";
       partial_json: string;
+    } | {
+      type: "thinking_delta";
+      thinking: string;
     };
     content_block?: {
       type: "text";
@@ -118,6 +121,9 @@ export interface ClaudeCliStreamEvent {
       type: "tool_use";
       id: string;
       name: string;
+    } | {
+      type: "thinking";
+      thinking: string;
     };
     message?: {
       model: string;
@@ -177,6 +183,14 @@ export function isInputJsonDelta(msg: ClaudeCliMessage): msg is ClaudeCliStreamE
     isStreamEvent(msg) &&
     msg.event.type === "content_block_delta" &&
     msg.event.delta?.type === "input_json_delta"
+  );
+}
+
+export function isThinkingDelta(msg: ClaudeCliMessage): msg is ClaudeCliStreamEvent {
+  return (
+    isStreamEvent(msg) &&
+    msg.event.type === "content_block_delta" &&
+    (msg.event.delta as { type?: string } | undefined)?.type === "thinking_delta"
   );
 }
 

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -11,9 +11,22 @@ export type OpenAIContentBlock =
   | { type: "text" | "input_text"; text: string }
   | { type: "image_url"; image_url: OpenAIImageUrl };
 
+export interface OpenAIToolDefinition {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
 export interface OpenAIChatMessage {
-  role: "system" | "user" | "assistant";
-  content: string | OpenAIContentBlock[];
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | OpenAIContentBlock[] | null;
+  /** Present on role="tool" messages: which tool call this result answers */
+  tool_call_id?: string;
+  /** Present on assistant messages that requested tool calls */
+  tool_calls?: OpenAIToolCall[];
 }
 
 export interface OpenAIChatRequest {
@@ -28,6 +41,8 @@ export interface OpenAIChatRequest {
   user?: string; // Used for session mapping
   reasoning_effort?: string; // OpenAI style: low/medium/high (also: xhigh/max)
   effort?: string; // Anthropic style alias
+  tools?: OpenAIToolDefinition[]; // Client-side tools (e.g. OpenWebUI functions/MCP)
+  tool_choice?: string | Record<string, unknown>;
 }
 
 export interface OpenAIToolCall {
@@ -77,6 +92,8 @@ export interface OpenAIChatResponse {
 export interface OpenAIChatChunkDelta {
   role?: "assistant";
   content?: string;
+  /** Extended thinking stream (OpenWebUI renders this as a collapsible section) */
+  reasoning?: string;
   tool_calls?: OpenAIToolCallChunk[];
 }
 

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -3,10 +3,13 @@
  * Used for Clawdbot integration
  */
 
-export interface OpenAIContentBlock {
-  type: "text" | "input_text";
-  text: string;
+export interface OpenAIImageUrl {
+  url: string; // http(s) URL or data:<mime>;base64,<data>
 }
+
+export type OpenAIContentBlock =
+  | { type: "text" | "input_text"; text: string }
+  | { type: "image_url"; image_url: OpenAIImageUrl };
 
 export interface OpenAIChatMessage {
   role: "system" | "user" | "assistant";
@@ -23,6 +26,8 @@ export interface OpenAIChatRequest {
   frequency_penalty?: number;
   presence_penalty?: number;
   user?: string; // Used for session mapping
+  reasoning_effort?: string; // OpenAI style: low/medium/high (also: xhigh/max)
+  effort?: string; // Anthropic style alias
 }
 
 export interface OpenAIToolCall {
@@ -64,6 +69,8 @@ export interface OpenAIChatResponse {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
   };
 }
 
@@ -89,6 +96,8 @@ export interface OpenAIChatChunk {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
   };
 }
 


### PR DESCRIPTION
## What

Feature pass-through improvements, all **live-tested in production** (OpenWebUI → this proxy → claude-opus-5):

**Vision support**
- `image_url` content blocks were silently dropped by `extractText()`. Now: base64 data URLs (what OpenWebUI sends) and remote http(s) URLs are staged as temp files; the prompt points Claude Code at them, and it views them via its `Read` tool
- Bounded to 20 MB/image, temp dirs cleaned up after every request (finally-block)

**Reasoning effort**
- `reasoning_effort` / `effort` request fields (`low|medium|high|xhigh|max`) → forwarded via the CLI's `--effort` flag, honored on resumed session turns too
- Unknown values fall back to the CLI default

**Cache metrics**
- Claude Code manages prompt caching automatically – but clients couldn't see it. `usage` now exposes `cache_read_input_tokens` / `cache_creation_input_tokens` (streaming + non-streaming)

**Model normalization**
- Response model names keep the major version: `claude-opus-5-...` → `claude-opus-5` instead of collapsing everything to `-4`

**Graceful first-run**
- Fresh deployments without credentials answer chat requests with actionable relogin guidance immediately, instead of running into the CLI's onboarding failure

**Note:** stacked on #15 (auth/admin layer) – merging in order avoids conflicts in `routes.ts`/`manager.ts`.