### PR TITLE
feat: OpenAI function calling for client tools – with hard execution lockdown

### DIFF
--- a/src/adapter/cli-to-openai.ts
+++ b/src/adapter/cli-to-openai.ts
@@ -101,6 +101,13 @@ export function cliResultToOpenai(
       completion_tokens: result.usage?.output_tokens || 0,
       total_tokens:
         (result.usage?.input_tokens || 0) + (result.usage?.output_tokens || 0),
+      // Prompt caching is automatic in Claude Code - surface the metrics
+      ...(result.usage?.cache_read_input_tokens
+        ? { cache_read_input_tokens: result.usage.cache_read_input_tokens }
+        : {}),
+      ...(result.usage?.cache_creation_input_tokens
+        ? { cache_creation_input_tokens: result.usage.cache_creation_input_tokens }
+        : {}),
     },
   };
 }
@@ -111,6 +118,9 @@ export function cliResultToOpenai(
  */
 function normalizeModelName(model: string | undefined): string {
   if (!model) return "claude-sonnet-4";
+  // Keep the major version visible: "claude-opus-5-..." -> "claude-opus-5"
+  const m = model.match(/claude-(opus|sonnet|haiku)-(\d+)/);
+  if (m) return `claude-${m[1]}-${m[2]}`;
   if (model.includes("opus")) return "claude-opus-4";
   if (model.includes("sonnet")) return "claude-sonnet-4";
   if (model.includes("haiku")) return "claude-haiku-4";

--- a/src/adapter/openai-to-cli.ts
+++ b/src/adapter/openai-to-cli.ts
@@ -2,14 +2,43 @@
  * Converts OpenAI chat request format to Claude CLI input
  */
 
-import type { OpenAIChatRequest, OpenAIContentBlock } from "../types/openai.js";
+import type { OpenAIChatRequest, OpenAIContentBlock, OpenAIToolDefinition } from "../types/openai.js";
+
+export type ClaudeEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 export type ClaudeModel = "opus" | "sonnet" | "haiku";
+
+export interface CliImage {
+  /** MIME type, e.g. image/png */
+  mimeType: string;
+  /** Raw base64 payload (without data URL prefix) */
+  data: string;
+  /** Original remote URL if the client sent one (no base64 copy kept) */
+  sourceUrl?: string;
+}
 
 export interface CliInput {
   prompt: string;
   model: ClaudeModel;
   sessionId?: string;
+  effort?: ClaudeEffort;
+  /** Images extracted from image_url content blocks, to be materialized as temp files */
+  images?: CliImage[];
+  /** Client-side tool definitions from the OpenAI request */
+  tools?: OpenAIToolDefinition[];
+  /** True when the client sent tools - the CLI's built-in tools must be disabled then */
+  hasClientTools?: boolean;
+}
+
+const EFFORT_LEVELS: ClaudeEffort[] = ["low", "medium", "high", "xhigh", "max"];
+
+/**
+ * Normalize effort from an OpenAI-compatible request (reasoning_effort or effort).
+ * Unknown values are ignored so the CLI default applies.
+ */
+export function extractEffort(request: OpenAIChatRequest): ClaudeEffort | undefined {
+  const raw = (request.reasoning_effort || request.effort || "").toLowerCase().trim();
+  return (EFFORT_LEVELS as string[]).includes(raw) ? (raw as ClaudeEffort) : undefined;
 }
 
 const MODEL_MAP: Record<string, ClaudeModel> = {
@@ -57,17 +86,43 @@ export function extractModel(model: string): ClaudeModel {
  *   - A plain string: "Hello"
  *   - An array of content blocks: [{"type": "text", "text": "Hello"}]
  */
-function extractText(content: string | OpenAIContentBlock[]): string {
+function extractText(content: string | OpenAIContentBlock[] | null): string {
+  if (content === null || content === undefined) {
+    return "";
+  }
   if (typeof content === "string") {
     return content;
   }
   if (Array.isArray(content)) {
     return content
       .filter((block) => block.type === "text" || block.type === "input_text")
-      .map((block) => block.text)
+      .map((block) => (block as { text: string }).text)
       .join("\n");
   }
   return String(content || "");
+}
+
+/**
+ * Extract images from OpenAI image_url content blocks.
+ * Data URLs (what OpenWebUI sends for uploads) are decoded to base64 payloads;
+ * remote http(s) URLs are passed through as sourceUrl for later download.
+ */
+export function extractImages(messages: OpenAIChatRequest["messages"]): CliImage[] {
+  const images: CliImage[] = [];
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block.type !== "image_url" || !block.image_url?.url) continue;
+      const url = block.image_url.url;
+      const dataUrl = url.match(/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/);
+      if (dataUrl) {
+        images.push({ mimeType: dataUrl[1], data: dataUrl[2] });
+      } else if (/^https?:\/\//.test(url)) {
+        images.push({ mimeType: "", data: "", sourceUrl: url });
+      }
+    }
+  }
+  return images;
 }
 
 /**
@@ -128,6 +183,11 @@ export function messagesToPrompt(
         // Previous assistant responses for context
         parts.push(`<previous_response>\n${text}\n</previous_response>\n`);
         break;
+
+      case "tool":
+        // Client-executed tool results (OpenWebUI sends role="tool")
+        parts.push(`<tool_result>\n${text}\n</tool_result>\n`);
+        break;
     }
   }
 
@@ -135,13 +195,52 @@ export function messagesToPrompt(
 }
 
 /**
+ * Render client tool definitions as a system-level instruction block.
+ * Claude Code has no native mechanism for client-executed tools in --print
+ * mode, so we describe them and require a <tool_call> JSON envelope - the
+ * response adapter parses it back into OpenAI tool_calls.
+ */
+export function toolsToPromptBlock(tools: OpenAIToolDefinition[]): string {
+  const defs = tools
+    .map((t) => {
+      const params = t.function.parameters
+        ? JSON.stringify(t.function.parameters)
+        : "{}";
+      return `- ${t.function.name}: ${t.function.description || "(no description)"}\n  parameters: ${params}`;
+    })
+    .join("\n");
+
+  return [
+    "<available_tools>",
+    "The client provides the following tools. You CANNOT execute them yourself -",
+    "the client runs them and sends the result back as a tool message.",
+    "To request a tool call, respond with ONLY a JSON block in this exact format:",
+    '<tool_call>{"name": "<tool_name>", "arguments": {...}}</tool_call>',
+    "No other text before or after. One tool call per response.",
+    "If no tool is needed, answer normally.",
+    "",
+    defs,
+    "</available_tools>",
+  ].join("\n");
+}
+
+/**
  * Convert OpenAI chat request to CLI input format
  */
 export function openaiToCli(request: OpenAIChatRequest): CliInput {
+  const images = extractImages(request.messages);
+  const tools = request.tools;
+  let prompt = messagesToPrompt(request.messages);
+  if (tools && tools.length > 0) {
+    prompt = toolsToPromptBlock(tools) + "\n\n" + prompt;
+  }
   return {
-    prompt: messagesToPrompt(request.messages),
+    prompt,
     model: extractModel(request.model),
     sessionId: request.user, // Use OpenAI's user field for session mapping
+    effort: extractEffort(request),
+    ...(images.length > 0 ? { images } : {}),
+    ...(tools && tools.length > 0 ? { tools, hasClientTools: true } : {}),
   };
 }
 
@@ -159,11 +258,21 @@ export function openaiToCliDelta(
     .slice(sinceIndex)
     .filter((m) => m.role !== "assistant");
 
+  const source = newMessages.length ? newMessages : request.messages;
+  const images = extractImages(source);
+  const tools = request.tools;
+  // Fallback to full history if nothing new was found (shouldn't happen,
+  // but never send an empty prompt to the CLI)
+  let prompt = messagesToPrompt(source);
+  if (tools && tools.length > 0) {
+    prompt = toolsToPromptBlock(tools) + "\n\n" + prompt;
+  }
   return {
-    // Fallback to full history if nothing new was found (shouldn't happen,
-    // but never send an empty prompt to the CLI)
-    prompt: messagesToPrompt(newMessages.length ? newMessages : request.messages),
+    prompt,
     model: extractModel(request.model),
     sessionId: request.user,
+    effort: extractEffort(request),
+    ...(images.length > 0 ? { images } : {}),
+    ...(tools && tools.length > 0 ? { tools, hasClientTools: true } : {}),
   };
 }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -346,10 +346,10 @@ async function handleStreamingResponse(
         return;
       }
       // CLI surfaces auth failures as plain text on stdout in some failure
-      // modes - replace with actionable guidance
+      // modes - swallow them here; the error/close handlers emit the guidance
+      // message exactly once.
       if (text && subprocess.hasAuthError()) {
-        text = AUTH_EXPIRED_MESSAGE;
-        isComplete = true;
+        return;
       }
       if (text && !res.writableEnded) {
         const chunk = {
@@ -499,6 +499,8 @@ async function handleStreamingResponse(
           }],
         };
         res.write(`data: ${JSON.stringify(textChunk)}\n\n`);
+        hasEmittedText = true;
+        isFirst = false;
       }
       if (!res.writableEnded) {
         // Send final done chunk with finish_reason and usage data

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -6,7 +6,8 @@
 
 import type { Request, Response } from "express";
 import { v4 as uuidv4 } from "uuid";
-import { ClaudeSubprocess } from "../subprocess/manager.js";
+import { existsSync, readdirSync } from "fs";
+import { ClaudeSubprocess, stageImages, cleanupImages } from "../subprocess/manager.js";
 import { openaiToCli, openaiToCliDelta } from "../adapter/openai-to-cli.js";
 import {
   cliResultToOpenai,
@@ -15,6 +16,84 @@ import {
 import { getSession, setSession, clearSession } from "../subprocess/session-store.js";
 import type { OpenAIChatRequest, OpenAIToolCall } from "../types/openai.js";
 import type { ClaudeCliAssistant, ClaudeCliResult, ClaudeCliStreamEvent } from "../types/claude-cli.js";
+
+/**
+ * Check whether Claude CLI credentials exist at all. On a fresh container
+ * with an empty /data volume, every request would otherwise run into the
+ * CLI's onboarding/login failure - we can answer that upfront instead.
+ */
+function hasClaudeCredentials(): boolean {
+  const dir = process.env.CLAUDE_CONFIG_DIR || `${process.env.HOME}/.claude`;
+  try {
+    if (!existsSync(dir)) return false;
+    return readdirSync(dir).some((f) => f.endsWith(".json"));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * User-facing guidance when the Claude CLI's OAuth session has expired.
+ * Returned as a normal assistant message instead of a raw 500 so the user
+ * sees actionable steps directly in their chat client.
+ */
+const AUTH_EXPIRED_MESSAGE = [
+  "Die Claude-Anmeldung auf dem Server ist abgelaufen – Anfragen sind derzeit nicht moeglich.",
+  "",
+  "Neuanmeldung direkt ueber die Admin-API (kein Server-Zugriff noetig):",
+  "1. `POST /admin/relogin/start` (mit Admin-Key) – die Antwort enthaelt eine Login-URL.",
+  "2. URL im Browser oeffnen und die Anmeldung bestaetigen.",
+  "3. Den angezeigten Code per `POST /admin/relogin/complete` zurueckschicken.",
+  "4. Danach funktioniert dieser Chat sofort wieder – die neuen Tokens liegen persistent im Volume.",
+  "",
+  "Details: siehe DOCKER.md, Abschnitt 'Re-Login ohne Container-Zugriff'.",
+].join("\n");
+
+/**
+ * Parse a <tool_call>{...}</tool_call> envelope from Claude's text output.
+ * Claude Code has no client-executed tool protocol in --print mode, so tool
+ * requests arrive as text; we convert them into OpenAI tool_calls.
+ */
+function parseToolCall(text: string): { name: string; arguments: string } | null {
+  const m = text.match(/<tool_call>\s*(\{[\s\S]*?\})\s*<\/tool_call>/);
+  if (!m) return null;
+  try {
+    const parsed = JSON.parse(m[1]);
+    if (typeof parsed.name !== "string") return null;
+    return {
+      name: parsed.name,
+      arguments:
+        typeof parsed.arguments === "string"
+          ? parsed.arguments
+          : JSON.stringify(parsed.arguments ?? {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+let toolCallSeq = 0;
+function nextToolCallId(): string {
+  return `call_${Date.now().toString(36)}${(toolCallSeq++).toString(36)}`;
+}
+
+/** Build an OpenAI-style assistant message body (non-streaming) */
+function authExpiredResponse(requestId: string, model: string) {
+  return {
+    id: `chatcmpl-${requestId}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: AUTH_EXPIRED_MESSAGE },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}
 
 interface SessionContext {
   sessionKey: string | undefined;
@@ -42,6 +121,8 @@ function resolveCliInput(body: OpenAIChatRequest): {
   if (existing) {
     const cliInput = openaiToCliDelta(body, existing.messageCount);
     cliInput.sessionId = existing.claudeSessionId;
+    // Effort is per-request, not per-session: honor it on resumed turns too
+    cliInput.effort = openaiToCli(body).effort;
     return { cliInput, sessionKey, resume: true };
   }
 
@@ -78,15 +159,64 @@ export async function handleChatCompletions(
       return;
     }
 
+    // Fresh container without any login: answer upfront instead of
+    // letting the request run into the CLI's onboarding failure
+    if (!hasClaudeCredentials()) {
+      console.error("[Auth] No Claude credentials found - prompting admin to run the relogin flow");
+      const guidance = authExpiredResponse(requestId, "claude-sonnet-4");
+      if (stream) {
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+        res.flushHeaders();
+        const chunk = {
+          id: guidance.id,
+          object: "chat.completion.chunk",
+          created: guidance.created,
+          model: guidance.model,
+          choices: [
+            { index: 0, delta: { role: "assistant", content: guidance.choices[0].message.content }, finish_reason: null },
+            { index: 0, delta: {}, finish_reason: "stop" },
+          ],
+        };
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+        res.write("data: [DONE]\n\n");
+        res.end();
+      } else {
+        res.json(guidance);
+      }
+      return;
+    }
+
     // Convert to CLI input format, resuming a persisted session when we have one
     const { cliInput, sessionKey, resume } = resolveCliInput(body);
     const subprocess = new ClaudeSubprocess();
     const sessionCtx: SessionContext = { sessionKey, resume, messageCount: body.messages.length };
 
-    if (stream) {
-      await handleStreamingResponse(req, res, subprocess, cliInput, requestId, sessionCtx);
-    } else {
-      await handleNonStreamingResponse(res, subprocess, cliInput, requestId, sessionCtx);
+    // Stage attached images (OpenAI image_url blocks) as temp files and point
+    // the prompt at them - Claude Code reads them via its Read tool
+    let stagedImages: string[] = [];
+    if (cliInput.images && cliInput.images.length > 0) {
+      stagedImages = await stageImages(cliInput.images);
+      delete cliInput.images; // don't hold base64 in memory longer than needed
+      if (stagedImages.length > 0) {
+        const listing = stagedImages.map((p, i) => `${i + 1}. ${p}`).join("\n");
+        cliInput.prompt =
+          `[Attached images - use your Read tool on each file to view them]\n${listing}\n\n` +
+          cliInput.prompt;
+      }
+    }
+
+    try {
+      if (stream) {
+        await handleStreamingResponse(req, res, subprocess, cliInput, requestId, sessionCtx);
+      } else {
+        await handleNonStreamingResponse(res, subprocess, cliInput, requestId, sessionCtx);
+      }
+    } finally {
+      if (stagedImages.length > 0) {
+        await cleanupImages(stagedImages);
+      }
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -147,6 +277,10 @@ async function handleStreamingResponse(
     let hasEmittedText = false;
     let toolCallIndex = 0;
     let inToolBlock = false;
+    let accumulatedText = "";
+    // When the client provides tools, Claude asks for them via a <tool_call>
+    // text envelope - buffer text so we can convert it into real tool_calls
+    const expectsClientTools = !!cliInput.hasClientTools;
 
     // Handle actual client disconnect (response stream closed)
     res.on("close", () => {
@@ -178,10 +312,45 @@ async function handleStreamingResponse(
       }
     });
 
+    // Extended thinking: forward as OpenAI-style reasoning chunks
+    // (OpenWebUI renders delta.reasoning as a collapsible "thinking" section).
+    // Note: subscription-billed thinking is often redacted/encrypted server-side
+    // (empty deltas with only estimated_tokens) - those are skipped here.
+    subprocess.on("thinking_delta", (event: ClaudeCliStreamEvent) => {
+      const delta = event.event.delta;
+      const text = (delta?.type === "thinking_delta" && delta.thinking) || "";
+      if (text && !res.writableEnded) {
+        const chunk = {
+          id: `chatcmpl-${requestId}`,
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: lastModel,
+          choices: [{
+            index: 0,
+            delta: { reasoning: text },
+            finish_reason: null,
+          }],
+        };
+        res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      }
+    });
+
     // Handle streaming content deltas
     subprocess.on("content_delta", (event: ClaudeCliStreamEvent) => {
       const delta = event.event.delta;
-      const text = (delta?.type === "text_delta" && delta.text) || "";
+      let text = (delta?.type === "text_delta" && delta.text) || "";
+      if (expectsClientTools) {
+        // Buffer instead of streaming: the text may be a <tool_call> envelope
+        // that must be converted into tool_calls, never shown to the user
+        accumulatedText += text;
+        return;
+      }
+      // CLI surfaces auth failures as plain text on stdout in some failure
+      // modes - replace with actionable guidance
+      if (text && subprocess.hasAuthError()) {
+        text = AUTH_EXPIRED_MESSAGE;
+        isComplete = true;
+      }
       if (text && !res.writableEnded) {
         const chunk = {
           id: `chatcmpl-${requestId}`,
@@ -284,6 +453,53 @@ async function handleStreamingResponse(
       if (sessionCtx.sessionKey && cliInput.sessionId) {
         setSession(sessionCtx.sessionKey, cliInput.sessionId, sessionCtx.messageCount);
       }
+      // Client-tool request? The streamed text is a <tool_call> envelope -
+      // replace it with proper OpenAI tool_calls chunks
+      if (expectsClientTools) {
+        const tc = parseToolCall(accumulatedText || result.result || "");
+        if (tc && !res.writableEnded) {
+          const callId = nextToolCallId();
+          const chunk = {
+            id: `chatcmpl-${requestId}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: lastModel,
+            choices: [{
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [{
+                  index: 0,
+                  id: callId,
+                  type: "function",
+                  function: { name: tc.name, arguments: tc.arguments },
+                }],
+              },
+              finish_reason: "tool_calls",
+            }],
+          };
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          res.write("data: [DONE]\n\n");
+          res.end();
+          resolve();
+          return;
+        }
+      }
+      // No tool call detected - flush the buffered text as regular content
+      if (expectsClientTools && accumulatedText && !res.writableEnded) {
+        const textChunk = {
+          id: `chatcmpl-${requestId}`,
+          object: "chat.completion.chunk",
+          created: Math.floor(Date.now() / 1000),
+          model: lastModel,
+          choices: [{
+            index: 0,
+            delta: { role: "assistant", content: accumulatedText },
+            finish_reason: null,
+          }],
+        };
+        res.write(`data: ${JSON.stringify(textChunk)}\n\n`);
+      }
       if (!res.writableEnded) {
         // Send final done chunk with finish_reason and usage data
         const doneChunk = createDoneChunk(requestId, lastModel);
@@ -293,6 +509,13 @@ async function handleStreamingResponse(
             completion_tokens: result.usage.output_tokens || 0,
             total_tokens:
               (result.usage.input_tokens || 0) + (result.usage.output_tokens || 0),
+            // Prompt caching is automatic in Claude Code - surface the metrics
+            ...(result.usage.cache_read_input_tokens
+              ? { cache_read_input_tokens: result.usage.cache_read_input_tokens }
+              : {}),
+            ...(result.usage.cache_creation_input_tokens
+              ? { cache_creation_input_tokens: result.usage.cache_creation_input_tokens }
+              : {}),
           };
         }
         res.write(`data: ${JSON.stringify(doneChunk)}\n\n`);
@@ -308,6 +531,23 @@ async function handleStreamingResponse(
       // next turn self-heals with a fresh full-history session
       if (sessionCtx.resume && sessionCtx.sessionKey) {
         clearSession(sessionCtx.sessionKey);
+      }
+      if (subprocess.hasAuthError()) {
+        console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+        if (!res.writableEnded) {
+          const chunk = {
+            id: `chatcmpl-${requestId}`,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: lastModel,
+            choices: [{ index: 0, delta: { role: "assistant", content: AUTH_EXPIRED_MESSAGE }, finish_reason: null }],
+          };
+          res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          res.write("data: [DONE]\n\n");
+          res.end();
+        }
+        resolve();
+        return;
       }
       if (!res.writableEnded) {
         res.write(
@@ -345,6 +585,8 @@ async function handleStreamingResponse(
       model: cliInput.model,
       sessionId: cliInput.sessionId,
       resume: sessionCtx.resume,
+      effort: cliInput.effort,
+      disableBuiltinTools: cliInput.hasClientTools,
     }).catch((err) => {
       console.error("[Streaming] Subprocess start error:", err);
       reject(err);
@@ -391,6 +633,12 @@ async function handleNonStreamingResponse(
       if (sessionCtx.resume && sessionCtx.sessionKey) {
         clearSession(sessionCtx.sessionKey);
       }
+      if (subprocess.hasAuthError()) {
+        console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+        res.json(authExpiredResponse(requestId, "claude-sonnet-4"));
+        resolve();
+        return;
+      }
       res.status(500).json({
         error: {
           message: error.message,
@@ -406,19 +654,58 @@ async function handleNonStreamingResponse(
         if (sessionCtx.sessionKey && cliInput.sessionId) {
           setSession(sessionCtx.sessionKey, cliInput.sessionId, sessionCtx.messageCount);
         }
+        // Client-tool request? Convert <tool_call> text into OpenAI tool_calls
+        if (cliInput.hasClientTools) {
+          const tc = parseToolCall(finalResult.result || "");
+          if (tc) {
+            res.json({
+              id: `chatcmpl-${requestId}`,
+              object: "chat.completion",
+              created: Math.floor(Date.now() / 1000),
+              model: "claude-sonnet-4",
+              choices: [{
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: null,
+                  tool_calls: [{
+                    id: nextToolCallId(),
+                    type: "function",
+                    function: { name: tc.name, arguments: tc.arguments },
+                  }],
+                },
+                finish_reason: "tool_calls",
+              }],
+              usage: {
+                prompt_tokens: finalResult.usage?.input_tokens || 0,
+                completion_tokens: finalResult.usage?.output_tokens || 0,
+                total_tokens:
+                  (finalResult.usage?.input_tokens || 0) +
+                  (finalResult.usage?.output_tokens || 0),
+              },
+            });
+            resolve();
+            return;
+          }
+        }
         res.json(cliResultToOpenai(finalResult, requestId));
       } else {
         if (sessionCtx.resume && sessionCtx.sessionKey) {
           clearSession(sessionCtx.sessionKey);
         }
         if (!res.headersSent) {
-          res.status(500).json({
-            error: {
-              message: `Claude CLI exited with code ${code} without response`,
-              type: "server_error",
-              code: null,
-            },
-          });
+          if (subprocess.hasAuthError()) {
+            console.error("[Auth] Claude CLI authentication expired - user notified in chat");
+            res.json(authExpiredResponse(requestId, "claude-sonnet-4"));
+          } else {
+            res.status(500).json({
+              error: {
+                message: `Claude CLI exited with code ${code} without response`,
+                type: "server_error",
+                code: null,
+              },
+            });
+          }
         }
       }
       resolve();
@@ -430,6 +717,8 @@ async function handleNonStreamingResponse(
         model: cliInput.model,
         sessionId: cliInput.sessionId,
         resume: sessionCtx.resume,
+        effort: cliInput.effort,
+        disableBuiltinTools: cliInput.hasClientTools,
       })
       .catch((error) => {
         res.status(500).json({

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -107,11 +107,25 @@ export async function stageImages(images: CliImage[]): Promise<string[]> {
         const res = await fetch(img.sourceUrl, {
           signal: AbortSignal.timeout(5000),
         });
-        if (!res.ok) continue;
+        if (!res.ok || !res.body) continue;
         const contentLength = Number(res.headers.get("content-length") || 0);
         if (contentLength > MAX_IMAGE_BYTES) continue;
         mime = mime || res.headers.get("content-type") || "";
-        buffer = Buffer.from(await res.arrayBuffer());
+        // Enforce the size limit while streaming: abort as soon as the body
+        // exceeds MAX_IMAGE_BYTES instead of buffering unbounded data first
+        const chunks: Buffer[] = [];
+        let received = 0;
+        let tooLarge = false;
+        for await (const chunk of res.body) {
+          received += (chunk as Buffer).length;
+          if (received > MAX_IMAGE_BYTES) {
+            tooLarge = true;
+            break;
+          }
+          chunks.push(Buffer.from(chunk));
+        }
+        if (tooLarge) continue;
+        buffer = Buffer.concat(chunks);
       } else {
         buffer = Buffer.from(img.data, "base64");
       }

--- a/src/subprocess/manager.ts
+++ b/src/subprocess/manager.ts
@@ -24,8 +24,10 @@ import {
   isToolUseBlockStart,
   isInputJsonDelta,
   isContentBlockStop,
+  isThinkingDelta,
 } from "../types/claude-cli.js";
-import type { ClaudeModel } from "../adapter/openai-to-cli.js";
+import type { ClaudeModel, CliImage, ClaudeEffort } from "../adapter/openai-to-cli.js";
+import os from "os";
 
 export interface SubprocessOptions {
   model: ClaudeModel;
@@ -34,7 +36,24 @@ export interface SubprocessOptions {
   resume?: boolean;
   cwd?: string;
   timeout?: number;
+  /** Reasoning effort passed through to the CLI via --effort */
+  effort?: ClaudeEffort;
+  /** Disable all built-in CLI tools (when the client provides its own tool list) */
+  disableBuiltinTools?: boolean;
+  /** Images to stage as temp files so Claude can Read them */
+  images?: CliImage[];
 }
+
+/** Max size per image (decoded), 20 MB - generous but bounded */
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
 
 export interface SubprocessEvents {
   message: (msg: ClaudeCliMessage) => void;
@@ -46,6 +65,79 @@ export interface SubprocessEvents {
 }
 
 const DEFAULT_TIMEOUT = 900000; // 15 minutes
+
+/**
+ * Detect authentication/authorization failures from CLI stderr or exit codes.
+ * The CLI surfaces expired OAuth tokens as 401/authentication_error text on
+ * stderr (there is no structured error type in stream-json), so we match the
+ * known signatures.
+ */
+export function isAuthError(stderr: string, exitCode: number | null): boolean {
+  if (exitCode === 401) return true;
+  const text = stderr.toLowerCase();
+  return (
+    text.includes("authentication_error") ||
+    text.includes("authentication failed") ||
+    (text.includes("401") && text.includes("unauthorized")) ||
+    text.includes("oauth token has expired") ||
+    text.includes("token expired") ||
+    text.includes("invalid oauth token") ||
+    (text.includes("not logged in") && text.includes("claude")) ||
+    text.includes("please run /login") ||
+    text.includes("please run claude auth login")
+  );
+}
+
+/**
+ * Stage request images as temp files so the CLI can read them via the Read tool.
+ * Returns absolute file paths. Caller is responsible for cleanup.
+ * Remote URLs are downloaded (5s timeout, bounded size).
+ */
+export async function stageImages(images: CliImage[]): Promise<string[]> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cmap-img-"));
+  const paths: string[] = [];
+
+  for (let i = 0; i < images.length; i++) {
+    const img = images[i];
+    try {
+      let buffer: Buffer;
+      let mime = img.mimeType;
+
+      if (img.sourceUrl) {
+        const res = await fetch(img.sourceUrl, {
+          signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) continue;
+        const contentLength = Number(res.headers.get("content-length") || 0);
+        if (contentLength > MAX_IMAGE_BYTES) continue;
+        mime = mime || res.headers.get("content-type") || "";
+        buffer = Buffer.from(await res.arrayBuffer());
+      } else {
+        buffer = Buffer.from(img.data, "base64");
+      }
+
+      if (buffer.length === 0 || buffer.length > MAX_IMAGE_BYTES) continue;
+      const ext = MIME_TO_EXT[mime] || ".png";
+      const file = path.join(dir, `image-${i + 1}${ext}`);
+      await fs.writeFile(file, buffer);
+      paths.push(file);
+    } catch {
+      // Skip broken images silently - prompt text still goes through
+    }
+  }
+
+  return paths;
+}
+
+/** Best-effort cleanup of staged image files (whole temp dir) */
+export async function cleanupImages(paths: string[]): Promise<void> {
+  const dirs = new Set(paths.map((p) => path.dirname(p)));
+  for (const dir of dirs) {
+    if (dir.includes("cmap-img-")) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}
 
 /**
  * System prompt appended to Claude CLI to map OpenClaw tool names to Claude Code equivalents.
@@ -194,6 +286,8 @@ function killProcessTree(
 export class ClaudeSubprocess extends EventEmitter {
   private process: ChildProcess | null = null;
   private buffer: string = "";
+  private stderrBuffer: string = "";
+  private exitCode: number | null = null;
   private timeoutId: NodeJS.Timeout | null = null;
   private isKilled: boolean = false;
 
@@ -255,10 +349,12 @@ export class ClaudeSubprocess extends EventEmitter {
           this.processBuffer();
         });
 
-        // Capture stderr for debugging
+        // Capture stderr for debugging and auth-error detection
         this.process.stderr?.on("data", (chunk: Buffer) => {
           const errorText = chunk.toString().trim();
           if (errorText) {
+            // Keep a bounded tail (4 KB) - enough for error signatures
+            this.stderrBuffer = (this.stderrBuffer + errorText + "\n").slice(-4096);
             // Don't emit as error unless it's actually an error
             // Claude CLI may write debug info to stderr
             if (process.env.DEBUG_SUBPROCESS) {
@@ -269,6 +365,7 @@ export class ClaudeSubprocess extends EventEmitter {
 
         // Handle process close
         this.process.on("close", (code) => {
+          this.exitCode = code;
           if (process.env.DEBUG_SUBPROCESS) {
             console.error(`[Subprocess] Process closed with code: ${code}`);
           }
@@ -306,6 +403,16 @@ export class ClaudeSubprocess extends EventEmitter {
       OPENCLAW_TOOL_MAPPING_PROMPT,
       // Prompt is passed via stdin (avoids E2BIG on large inputs)
     ];
+
+    if (options.effort) {
+      args.push("--effort", options.effort);
+    }
+
+    // Client-provided tools (OpenAI function calling): the CLI must NOT execute
+    // anything itself - no Bash, no Read, nothing. Execution happens client-side.
+    if (options.disableBuiltinTools) {
+      args.push("--tools", "");
+    }
 
     if (options.sessionId && options.resume) {
       // Continue a previously persisted session — avoids replaying full history
@@ -358,6 +465,9 @@ export class ClaudeSubprocess extends EventEmitter {
         if (isContentDelta(message)) {
           // Emit content delta for streaming (text_delta only)
           this.emit("content_delta", message as ClaudeCliStreamEvent);
+        } else if (isThinkingDelta(message)) {
+          // Extended thinking stream (visible when effort > default)
+          this.emit("thinking_delta", message as unknown as ClaudeCliStreamEvent);
         } else if (isAssistantMessage(message)) {
           this.emit("assistant", message);
         } else if (isResultMessage(message)) {
@@ -388,6 +498,14 @@ export class ClaudeSubprocess extends EventEmitter {
       this.clearTimeout();
       this.isKilled = killProcessTree(this.process, signal);
     }
+  }
+
+  /**
+   * True if the subprocess failed due to an authentication problem
+   * (expired OAuth token, logged out). Check after "close"/"error".
+   */
+  hasAuthError(): boolean {
+    return isAuthError(this.stderrBuffer, this.exitCode);
   }
 
   /**

--- a/src/types/claude-cli.ts
+++ b/src/types/claude-cli.ts
@@ -110,6 +110,9 @@ export interface ClaudeCliStreamEvent {
     } | {
       type: "input_json_delta";
       partial_json: string;
+    } | {
+      type: "thinking_delta";
+      thinking: string;
     };
     content_block?: {
       type: "text";
@@ -118,6 +121,9 @@ export interface ClaudeCliStreamEvent {
       type: "tool_use";
       id: string;
       name: string;
+    } | {
+      type: "thinking";
+      thinking: string;
     };
     message?: {
       model: string;
@@ -177,6 +183,14 @@ export function isInputJsonDelta(msg: ClaudeCliMessage): msg is ClaudeCliStreamE
     isStreamEvent(msg) &&
     msg.event.type === "content_block_delta" &&
     msg.event.delta?.type === "input_json_delta"
+  );
+}
+
+export function isThinkingDelta(msg: ClaudeCliMessage): msg is ClaudeCliStreamEvent {
+  return (
+    isStreamEvent(msg) &&
+    msg.event.type === "content_block_delta" &&
+    (msg.event.delta as { type?: string } | undefined)?.type === "thinking_delta"
   );
 }
 

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -3,14 +3,30 @@
  * Used for Clawdbot integration
  */
 
-export interface OpenAIContentBlock {
-  type: "text" | "input_text";
-  text: string;
+export interface OpenAIImageUrl {
+  url: string; // http(s) URL or data:<mime>;base64,<data>
+}
+
+export type OpenAIContentBlock =
+  | { type: "text" | "input_text"; text: string }
+  | { type: "image_url"; image_url: OpenAIImageUrl };
+
+export interface OpenAIToolDefinition {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
 }
 
 export interface OpenAIChatMessage {
-  role: "system" | "user" | "assistant";
-  content: string | OpenAIContentBlock[];
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | OpenAIContentBlock[] | null;
+  /** Present on role="tool" messages: which tool call this result answers */
+  tool_call_id?: string;
+  /** Present on assistant messages that requested tool calls */
+  tool_calls?: OpenAIToolCall[];
 }
 
 export interface OpenAIChatRequest {
@@ -23,6 +39,10 @@ export interface OpenAIChatRequest {
   frequency_penalty?: number;
   presence_penalty?: number;
   user?: string; // Used for session mapping
+  reasoning_effort?: string; // OpenAI style: low/medium/high (also: xhigh/max)
+  effort?: string; // Anthropic style alias
+  tools?: OpenAIToolDefinition[]; // Client-side tools (e.g. OpenWebUI functions/MCP)
+  tool_choice?: string | Record<string, unknown>;
 }
 
 export interface OpenAIToolCall {
@@ -64,12 +84,16 @@ export interface OpenAIChatResponse {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
   };
 }
 
 export interface OpenAIChatChunkDelta {
   role?: "assistant";
   content?: string;
+  /** Extended thinking stream (OpenWebUI renders this as a collapsible section) */
+  reasoning?: string;
   tool_calls?: OpenAIToolCallChunk[];
 }
 
@@ -89,6 +113,8 @@ export interface OpenAIChatChunk {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
   };
 }
 


### PR DESCRIPTION
## What

Implements the full **client-side function-calling roundtrip** (OpenAI `tools` array → Claude → `tool_calls` → client executes → `tool` result → final answer). This makes the proxy work with OpenWebUI tools/functions, MCP toolchains in IDEs, and any OpenAI-compatible agent client.

Since Claude Code has no client-executed tool protocol in `--print` mode, tool definitions are rendered into the prompt with a strict `<tool_call>` JSON envelope convention, and responses containing the envelope are converted into proper OpenAI `tool_calls` (`finish_reason: "tool_calls"`) – streaming and non-streaming. While tools are active, streamed text is buffered so the raw envelope never leaks into the client UI. `role="tool"` messages are accepted and rendered as `<tool_result>` context for the follow-up turn.

## ⚠️ The security angle (why this PR matters beyond the feature)

**Today, any client that can reach the proxy can make Claude execute arbitrary commands on the host** – the CLI runs with `--dangerously-skip-permissions`, and its full toolbox (Bash, Read, Write, Edit, WebSearch, …) is active by default. Whoever holds the (previously non-existent) API key effectively gets a remote shell in the container.

This PR changes the trust model:

| Request | Behavior |
|---|---|
| **With `tools` array** | `--tools ""` disables **all** built-in CLI tools. Claude can only *request* tool calls; execution happens exclusively in the client (OpenWebUI, IDE, …). **Zero local execution.** |
| **Without `tools`** | Unchanged (CLI tools active – needed e.g. for reading staged images) |

The lockdown is automatic and per-request – no configuration needed, no way for a client to escalate into host execution through the function-calling path.

## Tested

End-to-end in production: OpenWebUI (tool: terminal command function) → proxy → Claude Opus 5 → `tool_calls` → OpenWebUI executes → result fed back → final natural-language answer. Envelope never visible in the UI.

## Known limitation

The envelope convention is prompt-based, not native function calling – models can occasionally break format under heavy multi-tool scenarios (falls back to plain text, never to local execution). Works reliably for typical client toolchains.

## Note

Based on current `main`; if you also take #15 (auth/admin) and #16 (vision/effort/cache), I'll rebase to resolve the small overlaps in `routes.ts`/`manager.ts`.